### PR TITLE
ci.json: Updated model-config-tests to 0.0.8 and now uses access_esm1p6 test markers

### DIFF
--- a/config/ci.json
+++ b/config/ci.json
@@ -12,11 +12,11 @@
     },
     "qa": {
         "default": {
-            "markers": "access_esm1p5 or config"
+            "markers": "access_esm1p6 or config"
         }
     },
     "default": {
-        "model-config-tests-version": "0.0.7",
+        "model-config-tests-version": "0.0.8",
         "python-version": "3.11.0",
         "payu-version": "1.1.5"
     }


### PR DESCRIPTION
In this PR:
* Update the version of the model-config-tests class to `0.0.8` (contains changes from ACCESS-NRI/model-config-tests#90)
* Update default QA tests to use the new `access_esm1p6` markers
