### PR TITLE
Remove on.create Trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ on:
       - created
       - edited
   # For config-pr-3-bump-tag.yml
-  create:
   push:
     branches:
       - 'release-*'
@@ -59,7 +58,7 @@ jobs:
 
   bump-tag:
     name: Tag Bump
-    if: (github.event_name == 'push' || github.event_name == 'create' && github.ref_type == 'branch' && startsWith(github.ref_name, 'release-')) && github.repository != 'ACCESS-NRI/model-configs-template'
+    if: github.event_name == 'push' && github.repository != 'ACCESS-NRI/model-configs-template'
     uses: access-nri/model-config-tests/.github/workflows/config-pr-3-bump-tag.yml@main
     secrets: inherit
     permissions:


### PR DESCRIPTION
References ACCESS-NRI/model-config-tests#92

## Background

We currently have a scenario in configs repositories where we push a branch and open a pull request (quite a common occurence) which is associated with two event triggers: `on.create` and `on.pull_request.types.opened`. These are both associated with the same commit.

When the `on.pull_request.types.opened` event fires, which starts the QA/Repro checks, a check run is generated that contains the test results.

Unfortunately, having multiple event triggers when adding a check run makes the run associated with either the `on.create` trigger or the `on.pull_request` trigger, nondeterministically. See https://github.com/orgs/community/discussions/24616. This means that sometimes, in the first commit of a PR, we do not get the results of the QA/Repro checks. 

Since the workarounds are quite painful, we are just removing the `on.create` trigger. This means that it will be a bit more onerous to do the initial `release-*` branch creation. It is essentially a revert of https://github.com/ACCESS-NRI/model-config-tests/issues/58
