### PR TITLE
Increase collation walltime to 1.5h

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -116,7 +116,7 @@ collate:
     exe: mppnccombine.spack
     restart: true
     mem: 4GB
-    walltime: 1:00:00
+    walltime: 1:30:00
     mpi: false
 
 restart: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2024.12.10


### PR DESCRIPTION
Closes #32 
This PR increases the collation walltime to 1.5h to try and prevent occasional jobs where the walltime is exceeded.