### PR TITLE
Update UM code to be compatible with new cable namelist

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -26,7 +26,7 @@ modules:
   use:
       - /g/data/vk83/prerelease/modules
   load:
-      - access-esm1p6/pr27-5
+      - access-esm1p6/pr43-7
 
 # Model configuration
 model: access-esm1.6

--- a/manifests/exe.yaml
+++ b/manifests/exe.yaml
@@ -2,10 +2,10 @@ format: yamanifest
 version: 1.0
 ---
 work/atmosphere/um_hg3.exe:
-  fullpath: /g/data/vk83/prerelease/apps/spack/0.22/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/um7-git.dev-access-esm1.6_access-esm1.6-zpehauutrxs7mi2plup4zmj33kh3ofoi/bin/um_hg3.exe
+  fullpath: /g/data/vk83/prerelease/apps/spack/0.22/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/um7-git.70b173e38c1c6f523e7cb7c61f3767f3c7d01671_access-esm1.6-mnnf4kjfjkuv7ehxrdqw7mafazyyy5px/bin/um_hg3.exe
   hashes:
-    binhash: f7cac9ac22f6e5a0bd6b0c8c1526b58d
-    md5: a11697c817daa16c3659db8e7b75136c
+    binhash: 8c13ec5a74df936f45ce1d9c49ca1177
+    md5: 3a3fcc593d0d596bb50e0e242b426c80
 work/ice/cice_access_360x300_12x1_12p.exe:
   fullpath: /g/data/vk83/prerelease/apps/spack/0.22/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/cice4-git.update_DaveBi_access-esm1.5-o7ocdg6t5q7h6up75cvygv6v537xgh47/bin/cice_access_360x300_12x1_12p.exe
   hashes:


### PR DESCRIPTION
Closes preindustrial half of #47. Updates the executables to `pr43-7`, which should be compatible with the recent changes to the cable namelist.