### PR TITLE
Update UM to cable.nml compatible version

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -26,7 +26,7 @@ modules:
   use:
       - /g/data/vk83/prerelease/modules
   load:
-      - access-esm1p6/pr28-23
+      - access-esm1p6/pr43-7
 
 # Model configuration
 model: access-esm1.6


### PR DESCRIPTION
Closes AMIP half of #47. Updates the executables to `pr47-3`, which should be compatible with the updated cable namelists