### PR TITLE
Use LUH3 restart

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -119,7 +119,7 @@ collate:
     walltime: 1:30:00
     mpi: false
 
-restart: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2024.12.10
+restart: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17
 
 # Timing controls
 calendar:

--- a/manifests/restart.yaml
+++ b/manifests/restart.yaml
@@ -1,192 +1,197 @@
 format: yamanifest
 version: 1.0
 ---
-work/atmosphere/PI-02.astart-01010101:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2024.12.10/atmosphere/PI-02.astart-01010101
+work/atmosphere/PI-02-WithLUH3VegetationMap.astart:
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/atmosphere/PI-02-WithLUH3VegetationMap.astart
   hashes:
-    binhash: d329a23a6d7563038e2165a4e17c7907
-    md5: bfc4e6d8dfdb52d75e870adf62f2fb54
+    binhash: 8624025b842e993ac92da59cab28134c
+    md5: 437766c680ee4d28763aaa73fe3d5899
 work/atmosphere/restart_dump.astart:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2024.12.10/atmosphere/restart_dump.astart
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/atmosphere/restart_dump.astart
   hashes:
-    binhash: 5f4953143e0976cade7ee5a907e2e545
-    md5: bfc4e6d8dfdb52d75e870adf62f2fb54
+    binhash: 0b62cae6ab443122ef048f347457f76f
+    md5: 437766c680ee4d28763aaa73fe3d5899
 work/coupler/a2i.nc:
   copy: true
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2024.12.10/coupler/a2i.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/coupler/a2i.nc
   hashes:
     binhash: c26f2d428ef4c2abbae0d9761ee66b29
     md5: c8f135384aaf0b9a9119a441f76d3f32
 work/coupler/a2i.nc-01001231:
   copy: true
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2024.12.10/coupler/a2i.nc-01001231
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/coupler/a2i.nc-01001231
   hashes:
     binhash: 6f3ad48a2fa712bb76e3ac102ae4898f
     md5: c8f135384aaf0b9a9119a441f76d3f32
 work/coupler/i2a.nc:
   copy: true
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2024.12.10/coupler/i2a.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/coupler/i2a.nc
   hashes:
     binhash: 61a9e993e69761224538b39acc128fae
     md5: 87e48c0403e304fe20d21cb277dcc07a
 work/coupler/i2a.nc-01001231:
   copy: true
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2024.12.10/coupler/i2a.nc-01001231
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/coupler/i2a.nc-01001231
   hashes:
     binhash: 7a3fba386f1f8738ddd4d59c41d9105c
     md5: 87e48c0403e304fe20d21cb277dcc07a
 work/coupler/o2i.nc:
   copy: true
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2024.12.10/coupler/o2i.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/coupler/o2i.nc
   hashes:
     binhash: 53f914415f3f0c1ca4d7d64ce40b3ad1
     md5: b724ded00ce0f5ad5984b61bee1ad43e
 work/coupler/o2i.nc-01001231:
   copy: true
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2024.12.10/coupler/o2i.nc-01001231
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/coupler/o2i.nc-01001231
   hashes:
     binhash: b54510d75d48b84bf1b1699e009356d2
     md5: b724ded00ce0f5ad5984b61bee1ad43e
 work/ice/RESTART/cice_in.nml:
   copy: true
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2024.12.10/ice/cice_in.nml
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ice/cice_in.nml
   hashes:
     binhash: 065438e6ec01b615b9a50e9e8ee03eb6
     md5: 1576287c82da88ffc4752430100f848e
 work/ice/RESTART/ice.restart_file:
   copy: true
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2024.12.10/ice/ice.restart_file
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ice/ice.restart_file
   hashes:
     binhash: eb5295bbdde3f7455efdba11ad144b80
     md5: 2b181afa9524673b64612f3094427fbe
 work/ice/RESTART/ice.restart_file-01001231:
   copy: true
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2024.12.10/ice/ice.restart_file-01001231
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ice/ice.restart_file-01001231
   hashes:
     binhash: 9b3ac58940a4f2a4c1ca3293fb6c9273
     md5: 2b181afa9524673b64612f3094427fbe
 work/ice/RESTART/iced.01010101:
   copy: true
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2024.12.10/ice/iced.01010101
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ice/iced.01010101
   hashes:
     binhash: adcef41f7c92083c581de75e620365ba
     md5: d9d2e6e475ab3f94518e170a64c8d43e
 work/ice/RESTART/input_ice.nml:
   copy: true
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2024.12.10/ice/input_ice.nml
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ice/input_ice.nml
   hashes:
     binhash: 7b2d9db31d115b61876a592a5cd34cb6
     md5: e2d6d0541795dd3eeae54cda28ecba96
 work/ice/RESTART/mice.nc:
   copy: true
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2024.12.10/ice/mice.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ice/mice.nc
   hashes:
     binhash: ad3fafbc52aee03ccac6970a239766e7
     md5: 380a7008500f58eb5e8006b1eac18527
 work/ice/RESTART/mice.nc-01001231:
   copy: true
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2024.12.10/ice/mice.nc-01001231
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ice/mice.nc-01001231
   hashes:
     binhash: 86630cac8e3acfb2d69f60a6d0e1e40b
     md5: 380a7008500f58eb5e8006b1eac18527
 work/ice/RESTART/restart_date.nml:
   copy: true
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2024.12.10/ice/restart_date.nml
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ice/restart_date.nml
   hashes:
     binhash: 17fac552938796d021d131b8b5c0f191
     md5: da5f6db5c1b2dac11f27446f21db08cb
 work/ocean/INPUT/ocean_age.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2024.12.10/ocean/ocean_age.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ocean/ocean_age.res.nc
   hashes:
     binhash: 73b781f7e79c5382d43c69513e567cb7
     md5: 5ad601c0eaad3cfc3baa47aed91d1af9
 work/ocean/INPUT/ocean_barotropic.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2024.12.10/ocean/ocean_barotropic.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ocean/ocean_barotropic.res.nc
   hashes:
     binhash: a28a0924b37c8b22d11fdbffe5afc105
     md5: 97a5f4dc4a379ea4cad9f5d342ed6c51
 work/ocean/INPUT/ocean_bih_friction.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2024.12.10/ocean/ocean_bih_friction.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ocean/ocean_bih_friction.res.nc
   hashes:
     binhash: 57f14885eabee760edbcd5dc03df110c
     md5: 78ebb71bbf0e28e14d72243cf48a483c
 work/ocean/INPUT/ocean_density.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2024.12.10/ocean/ocean_density.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ocean/ocean_density.res.nc
   hashes:
     binhash: 1683d1032fb56b5f0cf63a890db0e0f4
     md5: 2ea72f188feac5017d4c7456f514e1e6
 work/ocean/INPUT/ocean_frazil.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2024.12.10/ocean/ocean_frazil.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ocean/ocean_frazil.res.nc
   hashes:
     binhash: 59f983ebd48d8bb4b85e9a12671917bb
     md5: dfd57082dc58081e9ed6b515f2d8a4c1
 work/ocean/INPUT/ocean_lap_friction.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2024.12.10/ocean/ocean_lap_friction.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ocean/ocean_lap_friction.res.nc
   hashes:
     binhash: 98f2376bee37c48160d09d8d090867b9
     md5: 2c1dbc74450e72925f9dbe7486689675
 work/ocean/INPUT/ocean_neutral.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2024.12.10/ocean/ocean_neutral.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ocean/ocean_neutral.res.nc
   hashes:
     binhash: b619d96024d81f27c146d5f1aee761a4
     md5: fab54ae81945add9ae5e850a4569ec34
 work/ocean/INPUT/ocean_pot_temp.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2024.12.10/ocean/ocean_pot_temp.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ocean/ocean_pot_temp.res.nc
   hashes:
     binhash: a5728081144e58008d000ee065410e00
     md5: dd179d49d13b0b11d524df725b6eec05
 work/ocean/INPUT/ocean_sbc.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2024.12.10/ocean/ocean_sbc.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ocean/ocean_sbc.res.nc
   hashes:
     binhash: fa7eb79171d6283309af858214d8a6d8
     md5: 655ee14d694588f2cdb870535df0b042
 work/ocean/INPUT/ocean_sigma_transport.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2024.12.10/ocean/ocean_sigma_transport.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ocean/ocean_sigma_transport.res.nc
   hashes:
     binhash: 1eb6035036f07358de1f9a03908d94f6
     md5: fe527a9917d30955d0dc082271c1392f
 work/ocean/INPUT/ocean_solo.res:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2024.12.10/ocean/ocean_solo.res
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ocean/ocean_solo.res
   hashes:
     binhash: 612a0d10f3acfcf78d4a5fa9473eb369
     md5: 354221e55782d6c1ffff3f9c3df24ffd
 work/ocean/INPUT/ocean_temp_salt.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2024.12.10/ocean/ocean_temp_salt.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ocean/ocean_temp_salt.res.nc
   hashes:
     binhash: 9f79790fcff30cd2284562045ee319d0
     md5: cd1b95ef3ac60f9e1f5af29d6bb2d4d5
 work/ocean/INPUT/ocean_thickness.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2024.12.10/ocean/ocean_thickness.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ocean/ocean_thickness.res.nc
   hashes:
     binhash: 5d4f9bde26e4554fb34c5b9ea7dac325
     md5: 5a9bbbca1e6fd2c963db84dda5a84acf
 work/ocean/INPUT/ocean_tracer.res:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2024.12.10/ocean/ocean_tracer.res
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ocean/ocean_tracer.res
   hashes:
     binhash: 4219ff58220b565482be8527fba50863
     md5: 5e5db59b3963b8130ccc76557ed2badc
 work/ocean/INPUT/ocean_velocity.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2024.12.10/ocean/ocean_velocity.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ocean/ocean_velocity.res.nc
   hashes:
     binhash: f63778183617313c83dbecc57619837c
     md5: 287edec7690400b797b1cbf6e1ea60f0
 work/ocean/INPUT/ocean_velocity_advection.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2024.12.10/ocean/ocean_velocity_advection.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ocean/ocean_velocity_advection.res.nc
   hashes:
     binhash: 99a342d73a013f4caf0c5e2d11a90a40
     md5: 653ffae21c9f0a18718d441d591798a1
 work/ocean/INPUT/ocean_wombatlite.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2024.12.10/ocean/ocean_wombatlite.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ocean/ocean_wombatlite.res.nc
   hashes:
-    binhash: 314b4f06c270dd097fd57d0cfedee5c1
-    md5: 951d801f3cc201f0c71aa88c367bed24
+    binhash: 39a911759643281abf7191051a078619
+    md5: 55f4d608998d4e908f645ac96b626224
 work/ocean/INPUT/ocean_wombatlite.res.nc-01001231-v20241210:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2024.12.10/ocean/ocean_wombatlite.res.nc-01001231-v20241210
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ocean/ocean_wombatlite.res.nc-01001231-v20241210
   hashes:
     binhash: 45a1b096c145110b1b177e667e51c568
     md5: b1c0623cab6acda07cf0b629110b52c5
 work/ocean/INPUT/ocean_wombatlite.res.nc-01001231-v20241211:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2024.12.10/ocean/ocean_wombatlite.res.nc-01001231-v20241211
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ocean/ocean_wombatlite.res.nc-01001231-v20241211
   hashes:
     binhash: ecf161044653c537ac13002ef5d188b0
     md5: 951d801f3cc201f0c71aa88c367bed24
+work/ocean/INPUT/ocean_wombatlite.res.nc-01001231-v20241211-2:
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ocean/ocean_wombatlite.res.nc-01001231-v20241211-2
+  hashes:
+    binhash: fdb90b2959114ffed3c86ce4ba884e0f
+    md5: 55f4d608998d4e908f645ac96b626224


### PR DESCRIPTION
Closes #39 

Adds the new LUH3 based restart as the default for the pre-industrial configuration.