### PR TITLE
Switch on LUC for AMIP run

### DIFF
--- a/atmosphere/cable.nml
+++ b/atmosphere/cable.nml
@@ -48,7 +48,7 @@
   satuParam = 0.8     ! only used if hydraulic redistribution .true.
 !
 ! CASA-CNP flags
-  l_luc = .FALSE.
+  l_luc = .TRUE.
   l_thinforest = .FALSE. 
   l_casacnp = .TRUE. ! redundant? actually controlled by icycle
   icycle = 3 ! Controls whether CASA-CNP is run and for which species


### PR DESCRIPTION
Closes #53 

Switches on `l_luc` for the AMIP configuration, as required for the land use change to run.


Compared to the AMIP namelist for ESM1.5, differences are:


```diff
diff esm1p5cable cable.nml 
3,5d2
<  filename%veg     = 'INPUT/def_veg_params.txt'
<  filename%soil    = 'INPUT/def_soil_params.txt'
< !
8a6
>   cable_user%GS_SWITCH = 'medlyn' ! alternative is 'leuning' - used for ESM1.5
15c13
<   cable_user%FWSOIL_SWITCH = 'standard' ! Controls root water uptake function
---
>   cable_user%FWSOIL_SWITCH = 'Haverd2013' ! Controls root water uptake function
34a34,39
>   cable_user%access13roots = .TRUE. ! TRUE uses prescribed froot values
>                                     ! FALSE uses 'rootbeta' parameterisation (as ACCESS-CM2)
>   cable_user%L_REV_CORR = .TRUE.
>   snmin = 0.11
>   cable_user%SOIL_THERMAL_FIX = .TRUE.
> 
58c63,64
<   casafile%cnpbiome='INPUT/pftlookup_csiro_v16_17tiles_wtlnds.csv'  ! biome specific BGC parameters
---
> ! updated pftlookup file for CABLE3 format
>   casafile%cnpbiome='INPUT/pftlookup_cable3.csv'  ! biome specific BGC parameters
```

Let me know if there's anything here not right for an amip simulation