### PR TITLE
Remove ocean output collation

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -113,11 +113,7 @@ submodels:
 
 # Collation
 collate:
-    exe: mppnccombine.spack
-    restart: true
-    mem: 4GB
-    walltime: 1:30:00
-    mpi: false
+    enable: false
 
 restart: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17
 

--- a/ocean/diagnostic_profiles/diag_table_detailed
+++ b/ocean/diagnostic_profiles/diag_table_detailed
@@ -599,48 +599,6 @@ ACCESS-ESM_CMIP6
 "ocean_model", "surface_o2", "surface_o2", "oceanbgc-2d-surface_o2-1monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
 
 
-# monthly 1d ocean fields
-
-"ocean-1d-1monthly-ym%4yr%2mo", 1, "months", 1, "days", "time", 1, "years"
-"ocean_model", "geolat_c", "geolat_c", "ocean-1d-1monthly-ym%4yr%2mo", "all", "none", "none", 2
-"ocean_model", "temp_merid_flux_advect_global", "temp_merid_flux_advect_global", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_over_global", "temp_merid_flux_over_global", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_gyre_global", "temp_merid_flux_gyre_global", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_advect_global", "salt_merid_flux_advect_global", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_over_global", "salt_merid_flux_over_global", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_gyre_global", "salt_merid_flux_gyre_global", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_advect_southern", "temp_merid_flux_advect_southern", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_over_southern", "temp_merid_flux_over_southern", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_gyre_southern", "temp_merid_flux_gyre_southern", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_advect_southern", "salt_merid_flux_advect_southern", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_over_southern", "salt_merid_flux_over_southern", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_gyre_southern", "salt_merid_flux_gyre_southern", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_advect_atlantic", "temp_merid_flux_advect_atlantic", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_over_atlantic", "temp_merid_flux_over_atlantic", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_gyre_atlantic", "temp_merid_flux_gyre_atlantic", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_advect_atlantic", "salt_merid_flux_advect_atlantic", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_over_atlantic", "salt_merid_flux_over_atlantic", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_gyre_atlantic", "salt_merid_flux_gyre_atlantic", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_advect_pacific", "temp_merid_flux_advect_pacific", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_over_pacific", "temp_merid_flux_over_pacific", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_gyre_pacific", "temp_merid_flux_gyre_pacific", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_advect_pacific", "salt_merid_flux_advect_pacific", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_over_pacific", "salt_merid_flux_over_pacific", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_gyre_pacific", "salt_merid_flux_gyre_pacific", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_advect_arctic", "temp_merid_flux_advect_arctic", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_over_arctic", "temp_merid_flux_over_arctic", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_gyre_arctic", "temp_merid_flux_gyre_arctic", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_advect_arctic", "salt_merid_flux_advect_arctic", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_over_arctic", "salt_merid_flux_over_arctic", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_gyre_arctic", "salt_merid_flux_gyre_arctic", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_advect_indian", "temp_merid_flux_advect_indian", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_over_indian", "temp_merid_flux_over_indian", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_gyre_indian", "temp_merid_flux_gyre_indian", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_advect_indian", "salt_merid_flux_advect_indian", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_over_indian", "salt_merid_flux_over_indian", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_gyre_indian", "salt_merid_flux_gyre_indian", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-
-
 # monthly scalar ocean fields
 
 "ocean-scalar-1monthly-ym%4yr%2mo", 1, "months", 1, "days", "time", 1, "years"

--- a/ocean/diagnostic_profiles/diag_table_standard
+++ b/ocean/diagnostic_profiles/diag_table_standard
@@ -602,48 +602,6 @@ ACCESS-ESM_CMIP6
 "ocean_model", "surface_o2", "surface_o2", "oceanbgc-2d-surface_o2-1monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
 
 
-# monthly 1d ocean fields
-
-"ocean-1d-1monthly-ym%4yr%2mo", 1, "months", 1, "days", "time", 1, "years"
-"ocean_model", "geolat_c", "geolat_c", "ocean-1d-1monthly-ym%4yr%2mo", "all", "none", "none", 2
-"ocean_model", "temp_merid_flux_advect_global", "temp_merid_flux_advect_global", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_over_global", "temp_merid_flux_over_global", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_gyre_global", "temp_merid_flux_gyre_global", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_advect_global", "salt_merid_flux_advect_global", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_over_global", "salt_merid_flux_over_global", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_gyre_global", "salt_merid_flux_gyre_global", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_advect_southern", "temp_merid_flux_advect_southern", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_over_southern", "temp_merid_flux_over_southern", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_gyre_southern", "temp_merid_flux_gyre_southern", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_advect_southern", "salt_merid_flux_advect_southern", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_over_southern", "salt_merid_flux_over_southern", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_gyre_southern", "salt_merid_flux_gyre_southern", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_advect_atlantic", "temp_merid_flux_advect_atlantic", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_over_atlantic", "temp_merid_flux_over_atlantic", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_gyre_atlantic", "temp_merid_flux_gyre_atlantic", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_advect_atlantic", "salt_merid_flux_advect_atlantic", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_over_atlantic", "salt_merid_flux_over_atlantic", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_gyre_atlantic", "salt_merid_flux_gyre_atlantic", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_advect_pacific", "temp_merid_flux_advect_pacific", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_over_pacific", "temp_merid_flux_over_pacific", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_gyre_pacific", "temp_merid_flux_gyre_pacific", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_advect_pacific", "salt_merid_flux_advect_pacific", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_over_pacific", "salt_merid_flux_over_pacific", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_gyre_pacific", "salt_merid_flux_gyre_pacific", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_advect_arctic", "temp_merid_flux_advect_arctic", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_over_arctic", "temp_merid_flux_over_arctic", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_gyre_arctic", "temp_merid_flux_gyre_arctic", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_advect_arctic", "salt_merid_flux_advect_arctic", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_over_arctic", "salt_merid_flux_over_arctic", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_gyre_arctic", "salt_merid_flux_gyre_arctic", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_advect_indian", "temp_merid_flux_advect_indian", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_over_indian", "temp_merid_flux_over_indian", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_gyre_indian", "temp_merid_flux_gyre_indian", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_advect_indian", "salt_merid_flux_advect_indian", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_over_indian", "salt_merid_flux_over_indian", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_gyre_indian", "salt_merid_flux_gyre_indian", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-
-
 # monthly scalar ocean fields
 
 "ocean-scalar-1monthly-ym%4yr%2mo", 1, "months", 1, "days", "time", 1, "years"

--- a/ocean/diagnostic_profiles/diag_table_wombatlite
+++ b/ocean/diagnostic_profiles/diag_table_wombatlite
@@ -791,48 +791,6 @@ ACCESS-ESM_CMIP6
 "ocean_model", "surface_o2", "surface_o2", "oceanbgc-2d-surface_o2-1monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
 
 
-# monthly 1d ocean fields
-
-"ocean-1d-1monthly-ym%4yr%2mo", 1, "months", 1, "days", "time", 1, "years"
-"ocean_model", "geolat_c", "geolat_c", "ocean-1d-1monthly-ym%4yr%2mo", "all", "none", "none", 2
-"ocean_model", "temp_merid_flux_advect_global", "temp_merid_flux_advect_global", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_over_global", "temp_merid_flux_over_global", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_gyre_global", "temp_merid_flux_gyre_global", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_advect_global", "salt_merid_flux_advect_global", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_over_global", "salt_merid_flux_over_global", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_gyre_global", "salt_merid_flux_gyre_global", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_advect_southern", "temp_merid_flux_advect_southern", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_over_southern", "temp_merid_flux_over_southern", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_gyre_southern", "temp_merid_flux_gyre_southern", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_advect_southern", "salt_merid_flux_advect_southern", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_over_southern", "salt_merid_flux_over_southern", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_gyre_southern", "salt_merid_flux_gyre_southern", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_advect_atlantic", "temp_merid_flux_advect_atlantic", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_over_atlantic", "temp_merid_flux_over_atlantic", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_gyre_atlantic", "temp_merid_flux_gyre_atlantic", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_advect_atlantic", "salt_merid_flux_advect_atlantic", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_over_atlantic", "salt_merid_flux_over_atlantic", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_gyre_atlantic", "salt_merid_flux_gyre_atlantic", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_advect_pacific", "temp_merid_flux_advect_pacific", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_over_pacific", "temp_merid_flux_over_pacific", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_gyre_pacific", "temp_merid_flux_gyre_pacific", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_advect_pacific", "salt_merid_flux_advect_pacific", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_over_pacific", "salt_merid_flux_over_pacific", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_gyre_pacific", "salt_merid_flux_gyre_pacific", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_advect_arctic", "temp_merid_flux_advect_arctic", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_over_arctic", "temp_merid_flux_over_arctic", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_gyre_arctic", "temp_merid_flux_gyre_arctic", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_advect_arctic", "salt_merid_flux_advect_arctic", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_over_arctic", "salt_merid_flux_over_arctic", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_gyre_arctic", "salt_merid_flux_gyre_arctic", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_advect_indian", "temp_merid_flux_advect_indian", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_over_indian", "temp_merid_flux_over_indian", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "temp_merid_flux_gyre_indian", "temp_merid_flux_gyre_indian", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_advect_indian", "salt_merid_flux_advect_indian", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_over_indian", "salt_merid_flux_over_indian", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-"ocean_model", "salt_merid_flux_gyre_indian", "salt_merid_flux_gyre_indian", "ocean-1d-1monthly-ym%4yr%2mo", "all", "average", "none", 2
-
-
 # monthly scalar ocean fields
 
 "ocean-scalar-1monthly-ym%4yr%2mo", 1, "months", 1, "days", "time", 1, "years"

--- a/ocean/input.nml
+++ b/ocean/input.nml
@@ -202,6 +202,7 @@
 
  &ocean_model_nml
       layout = 18,10
+      io_layout = 1,1
       time_tendency='twolevel'
       vertical_coordinate='zstar'
       dt_ocean = 3600
@@ -211,6 +212,11 @@
       cmip_units=.true.
       debug=.false.
       do_wave=.true.
+/
+
+&mpp_io_nml
+    deflate_level     = 4
+    shuffle           = 1
 /
 
  &ocean_momentum_source_nml


### PR DESCRIPTION
Work related to #41.

Collation failures form the majority of post-processing problems which have recently caused problems during esm.6 development. Based on discussions, the preference is to remove the collation step entirely by writing complete ocean output files during the model run. 

This pull request sets the ocean `io_layout=1,1` and switches off the collation step. Additionally, compression is enabled for the MOM output with `deflate=4` to maintain similar output sizes as before. 

Adding an `io_layout` requires us to remove  the basin specific flux variables. Including these with an `io_layout` can either cause the model to crash, or silently write wrong output. See [here](https://github.com/ACCESS-NRI/access-esm1.6-configs/issues/51) for details.

This change impacts the model walltime, increasing by ~3-7 minutes depending on the out. See [here](https://github.com/ACCESS-NRI/access-esm1.6-configs/issues/41#issuecomment-2712197438) and [here](https://github.com/ACCESS-NRI/access-esm1.6-configs/issues/41#issuecomment-2722901346) for details.


