### PR TITLE
Add checksum_slow to default repro checks

### DIFF
--- a/config/ci.json
+++ b/config/ci.json
@@ -7,7 +7,7 @@
     },
     "reproducibility": {
         "default": {
-            "markers": "checksum"
+            "markers": "checksum or checksum_slow"
         }
     },
     "qa": {
@@ -16,8 +16,8 @@
         }
     },
     "default": {
-        "model-config-tests-version": "0.0.9",
+        "model-config-tests-version": "main",
         "python-version": "3.11.0",
-        "payu-version": "1.1.5"
+        "payu-version": "dev"
     }
 }


### PR DESCRIPTION
As we discussed in person, this PR reconfigures the CI to:
- run `reproducibility` checksum and checksum_slow marks by default (meaning historical, restart and repeat repro tests are run)
- use payu dev
- use the latest `model-config-tests`

These settings should be revisited when we are ready to release a config.