### PR TITLE
Update CI test markers

### DIFF
--- a/config/ci.json
+++ b/config/ci.json
@@ -2,12 +2,12 @@
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/configuration/ci/2-0-0.json",
     "scheduled": {
         "default": {
-            "markers": "checksum"
+            "markers": "repro and (not slow)"
         }
     },
     "reproducibility": {
         "default": {
-            "markers": "checksum or checksum_slow"
+            "markers": "repro and (not repro_restart)"
         }
     },
     "qa": {


### PR DESCRIPTION
This PR updates the CI test markers according to [incoming changes to `model-config-tests`](https://github.com/ACCESS-NRI/model-config-tests/pull/137).

This shouldn't be merged until https://github.com/ACCESS-NRI/model-config-tests/pull/137 is merged.