### PR TITLE
Test ACCESS-ESM1.6 with openmpi 4.1.5 and ifort 2021.10.0

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -24,9 +24,9 @@ jobfs: 1500MB
 # Modules for loading model executables
 modules:
   use:
-      - /g/data/vk83/modules
+      - /g/data/vk83/prerelease/modules
   load:
-      - access-esm1p6/dev_2025.03.1
+      - access-esm1p6/pr53-17
 
 # Model configuration
 model: access-esm1.6

--- a/manifests/exe.yaml
+++ b/manifests/exe.yaml
@@ -2,17 +2,17 @@ format: yamanifest
 version: 1.0
 ---
 work/atmosphere/um_hg3.exe:
-  fullpath: /g/data/vk83/apps/spack/0.22/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/um7-git.86a4e1fc37cb1d6fc1dae536deb5c0bd104506bf_access-esm1.6-slt5rjrhzls2ilx5yl5yvzufd2c72xd7/bin/um_hg3.exe
+  fullpath: /g/data/vk83/prerelease/apps/spack/0.22/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-2021.10.0/um7-git.86a4e1fc37cb1d6fc1dae536deb5c0bd104506bf_access-esm1.6-rzvjz25tv4elin5pxkb6juavjqcm4lpr/bin/um_hg3.exe
   hashes:
-    binhash: f04b1680fbce720ca92ceecc33c584bb
-    md5: 45d5010d88560cef077f4323f996816f
+    binhash: eba3ed0001c0e5aef8f5df8f1cbec93e
+    md5: 9abf3de71dfecb330f5dfa541e00b977
 work/ice/cice_access_360x300_12x1_12p.exe:
-  fullpath: /g/data/vk83/apps/spack/0.22/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/cice4-git.b51e3529bd78fd852760e348983e2334341f861d_access-esm1.5-6btn7f2rx42b5onckzd227btqkhq6phf/bin/cice_access_360x300_12x1_12p.exe
+  fullpath: /g/data/vk83/prerelease/apps/spack/0.22/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-2021.10.0/cice4-git.b51e3529bd78fd852760e348983e2334341f861d_access-esm1.5-4llcfu2r5pzxhla6dt3qvtlfazvbw62e/bin/cice_access_360x300_12x1_12p.exe
   hashes:
-    binhash: 4a929bf1561e19bfcdfed7577281a970
-    md5: 6741d9b07e889111aa23f4b6e85f7d22
+    binhash: 2d9e9b2d147ebb019e758046cf57843b
+    md5: 3ab258dd199ac192e6f1626a736b8d18
 work/ocean/fms_ACCESS-ESM.x:
-  fullpath: /g/data/vk83/apps/spack/0.22/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/mom5-git.dev-2025.03.001_access-esm1.6-itjaiklnfjml66kmrah4gkkzyioeq4k7/bin/fms_ACCESS-ESM.x
+  fullpath: /g/data/vk83/prerelease/apps/spack/0.22/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-2021.10.0/mom5-git.dev-2025.03.001_access-esm1.6-w6nzi2dln3of6smkmflrymw6vv4izxhs/bin/fms_ACCESS-ESM.x
   hashes:
-    binhash: d88be50322d7a28924f5061902d57bba
-    md5: 0104946ba5d160c1c5496219a3d7aee8
+    binhash: 190f9167d559f7bc33630432966db7ed
+    md5: ef6efee2b32b98a5a39e0155693d2b6e


### PR DESCRIPTION
**DO NOT MERGE**

Companion PR to https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/53 to test and report reproducibility and performance impacts of building ACCESS-ESM1.6 with openmpi 4.1.5 and ifort 2021.10.0