### PR TITLE
Update config.yaml to point to relevant prerelease

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -26,7 +26,7 @@ modules:
   use:
       - /g/data/vk83/modules
   load:
-      - access-esm1p6/dev_2025.03.1
+      - access-esm1p6/pr63-1
 
 # Model configuration
 model: access-esm1.6


### PR DESCRIPTION
Prerelease build has additional UM flags to initialise scalars and arrays with a given value to get around non-determinism issue. Repro should fail here- if it doesn't indicates there's an issue with the tests.