### PR TITLE
Checking for AMIP repro with oneAPI exe (draft)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -26,7 +26,7 @@ modules:
   use:
       - /g/data/vk83/prerelease/modules
   load:
-      - access-esm1p6/pr43-7
+      - access-esm1p6/pr67-2
 
 # Model configuration
 model: access-esm1.6


### PR DESCRIPTION
Do not merge

Not really sure why the [other PR got closed](https://github.com/ACCESS-NRI/access-esm1.6-configs/pull/66) when I changed the target to `main` instead of `dev-amip`.

@blimlim I am trying to run the repro test with the exes built with oneAPI. I branched off `dev-amip` - so presumably repro should test against that - right? 