### PR TITLE
Update amip exe for determinism fix

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -24,9 +24,9 @@ jobfs: 1500MB
 # Modules for loading model executables
 modules:
   use:
-      - /g/data/vk83/prerelease/modules
+      - /g/data/vk83/modules
   load:
-      - access-esm1p6/pr43-7
+      - access-esm1p6/dev_2025.03.1
 
 # Model configuration
 model: access-esm1.6

--- a/manifests/exe.yaml
+++ b/manifests/exe.yaml
@@ -2,7 +2,7 @@ format: yamanifest
 version: 1.0
 ---
 work/atmosphere/um_hg3.exe:
-  fullpath: /g/data/vk83/prerelease/apps/spack/0.22/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/um7-git.70b173e38c1c6f523e7cb7c61f3767f3c7d01671_access-esm1.6-mnnf4kjfjkuv7ehxrdqw7mafazyyy5px/bin/um_hg3.exe
+  fullpath: /g/data/vk83/apps/spack/0.22/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/um7-git.86a4e1fc37cb1d6fc1dae536deb5c0bd104506bf_access-esm1.6-slt5rjrhzls2ilx5yl5yvzufd2c72xd7/bin/um_hg3.exe
   hashes:
-    binhash: 8c13ec5a74df936f45ce1d9c49ca1177
-    md5: 3a3fcc593d0d596bb50e0e242b426c80
+    binhash: f04b1680fbce720ca92ceecc33c584bb
+    md5: 45d5010d88560cef077f4323f996816f


### PR DESCRIPTION
Closes #69.

This updates the `dev-amip` configuration executables to match the `dev-preindustrial+concentrations` branch, in particular bringing in a fix which makes the UM deterministic.

