### PR TITLE
Add `checks: write` Permission to Generate Initial Checksums

### DIFF
--- a/.github/workflows/generate-initial-checksums.yml
+++ b/.github/workflows/generate-initial-checksums.yml
@@ -76,4 +76,5 @@ jobs:
       payu-version: ${{ needs.config.outputs.payu-version }}
     permissions:
       contents: write
+      checks: write
     secrets: inherit


### PR DESCRIPTION
Closes #73

## Background

A later workflow is requiring `checks: write` but we didn't give that permission initially. Now we do.

## In this PR

* Give the repro-ci job `permissions.checks: write`
