### PR TITLE
generate-initial-checksums: Update workflow version

### DIFF
--- a/.github/workflows/generate-initial-checksums.yml
+++ b/.github/workflows/generate-initial-checksums.yml
@@ -34,7 +34,7 @@ jobs:
   generate-checksums:
     name: Generate Checksums
     if: github.repository != 'access-nri/model-config-tests'
-    uses: access-nri/model-config-tests/.github/workflows/generate-checksums.yml@146-add-marker-input-for-initial-checksums
+    uses: access-nri/model-config-tests/.github/workflows/generate-checksums.yml@main
     with:
       config-branch-name: ${{ inputs.config-branch-name }}
       commit-checksums: ${{ inputs.commit-checksums }}


### PR DESCRIPTION
Following on from this PR: https://github.com/ACCESS-NRI/access-esm1.6-configs/pull/75, this PR updates the branch of the `generate-checksums` workflow in `model-config-tests` to `main`. The branch `146-add-marker-input-for-initial-checksums` has now been merged in https://github.com/ACCESS-NRI/model-config-tests/pull/147