### PR TITLE
Update config to point to prerelease build

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -26,7 +26,7 @@ modules:
   use:
       - /g/data/vk83/modules
   load:
-      - access-esm1p6/dev_2025.03.1
+      - access-esm1p6/pr68-4
 
 # Model configuration
 model: access-esm1.6


### PR DESCRIPTION
Config update to point to prerelease as part of [this PR](https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/68). Only change is adding ```SOURCE``` argument to ```ALLOCATE``` calls- should make no difference in scientific results, but should make first set of UM7 diagnostic results deterministic.