### PR TITLE
Use the CMIP7 pre-industrial solar constant

### DIFF
--- a/atmosphere/input_atm.nml
+++ b/atmosphere/input_atm.nml
@@ -1,7 +1,7 @@
 &coupling
  access_tfs=-1.8
  xfactor=1.0
- SC=1365.65
+ SC=1361.62
  co2_init=284.725
  VOLCTS_val=133.8
  ocn_sss=.false.


### PR DESCRIPTION
Update `input_atm.nml` with new solar constant.

See #82 and https://github.com/ACCESS-Community-Hub/access-esm1.6-dev-experiments/issues/7