### PR TITLE
Use new combined restart file

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -119,7 +119,7 @@ submodels:
 collate:
     enable: false
 
-restart: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17
+restart: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08 
 
 # Timing controls
 calendar:

--- a/manifests/restart.yaml
+++ b/manifests/restart.yaml
@@ -1,197 +1,199 @@
 format: yamanifest
 version: 1.0
 ---
-work/atmosphere/PI-02-WithLUH3VegetationMap.astart:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/atmosphere/PI-02-WithLUH3VegetationMap.astart
-  hashes:
-    binhash: 8624025b842e993ac92da59cab28134c
-    md5: 437766c680ee4d28763aaa73fe3d5899
 work/atmosphere/restart_dump.astart:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/atmosphere/restart_dump.astart
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/atmosphere/restart_dump.astart
   hashes:
-    binhash: 0b62cae6ab443122ef048f347457f76f
-    md5: 437766c680ee4d28763aaa73fe3d5899
+    binhash: 00e57561d6798aca3ee1e2548992d4ac
+    md5: 3e781fb782251877be8b065b48fd5901
+work/atmosphere/um.res.yaml:
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/atmosphere/um.res.yaml
+  hashes:
+    binhash: b59017d5da701866bc98a6d766ea1873
+    md5: 02387e3533dd4a73ff83b29b14d1f1d2
 work/coupler/a2i.nc:
   copy: true
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/coupler/a2i.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/coupler/a2i.nc
   hashes:
-    binhash: c26f2d428ef4c2abbae0d9761ee66b29
-    md5: c8f135384aaf0b9a9119a441f76d3f32
-work/coupler/a2i.nc-01001231:
-  copy: true
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/coupler/a2i.nc-01001231
-  hashes:
-    binhash: 6f3ad48a2fa712bb76e3ac102ae4898f
-    md5: c8f135384aaf0b9a9119a441f76d3f32
+    binhash: 3e225c23a5e0f6d6dae8ec7fae51739d
+    md5: 19f07ed3d650fe59f8ef0c924b158c7b
 work/coupler/i2a.nc:
   copy: true
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/coupler/i2a.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/coupler/i2a.nc
   hashes:
-    binhash: 61a9e993e69761224538b39acc128fae
-    md5: 87e48c0403e304fe20d21cb277dcc07a
-work/coupler/i2a.nc-01001231:
-  copy: true
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/coupler/i2a.nc-01001231
-  hashes:
-    binhash: 7a3fba386f1f8738ddd4d59c41d9105c
-    md5: 87e48c0403e304fe20d21cb277dcc07a
+    binhash: 62cfcaaf65941215882355a2a070b24e
+    md5: 1eb74ae43c42902b2428008fe4862eb0
 work/coupler/o2i.nc:
   copy: true
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/coupler/o2i.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/coupler/o2i.nc
   hashes:
-    binhash: 53f914415f3f0c1ca4d7d64ce40b3ad1
-    md5: b724ded00ce0f5ad5984b61bee1ad43e
-work/coupler/o2i.nc-01001231:
-  copy: true
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/coupler/o2i.nc-01001231
-  hashes:
-    binhash: b54510d75d48b84bf1b1699e009356d2
-    md5: b724ded00ce0f5ad5984b61bee1ad43e
+    binhash: 6ba525fc18cade8517fd4341e81fd536
+    md5: 9b2b1f77c89e82d6aef4b0a8cdaac91f
 work/ice/RESTART/cice_in.nml:
   copy: true
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ice/cice_in.nml
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/ice/cice_in.nml
   hashes:
-    binhash: 065438e6ec01b615b9a50e9e8ee03eb6
-    md5: 1576287c82da88ffc4752430100f848e
+    binhash: 421a4cb665f5ecfd1bc0b2fbd102e8c9
+    md5: c7f4efa06b54d2056cb7ee79c0ceeabd
 work/ice/RESTART/ice.restart_file:
   copy: true
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ice/ice.restart_file
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/ice/ice.restart_file
   hashes:
-    binhash: eb5295bbdde3f7455efdba11ad144b80
-    md5: 2b181afa9524673b64612f3094427fbe
+    binhash: e09f208fa97988978c6e8ceb123fc69b
+    md5: 434d1825680bf78b8c6ca30d34701f35
 work/ice/RESTART/ice.restart_file-01001231:
   copy: true
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ice/ice.restart_file-01001231
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/ice/ice.restart_file-01001231
   hashes:
-    binhash: 9b3ac58940a4f2a4c1ca3293fb6c9273
+    binhash: cc617503c61765f7b3fa3d2a6ee66b2d
     md5: 2b181afa9524673b64612f3094427fbe
 work/ice/RESTART/iced.01010101:
   copy: true
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ice/iced.01010101
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/ice/iced.01010101
   hashes:
-    binhash: adcef41f7c92083c581de75e620365ba
-    md5: d9d2e6e475ab3f94518e170a64c8d43e
+    binhash: fd6f4284e09f377e7f32047bde412876
+    md5: 99ca0d4c6ecd68178c63b5ae85e69d51
 work/ice/RESTART/input_ice.nml:
   copy: true
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ice/input_ice.nml
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/ice/input_ice.nml
   hashes:
-    binhash: 7b2d9db31d115b61876a592a5cd34cb6
+    binhash: 19680aa5529ce69fdb39a9acaa8de03b
     md5: e2d6d0541795dd3eeae54cda28ecba96
 work/ice/RESTART/mice.nc:
   copy: true
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ice/mice.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/ice/mice.nc
   hashes:
-    binhash: ad3fafbc52aee03ccac6970a239766e7
-    md5: 380a7008500f58eb5e8006b1eac18527
+    binhash: ff75e72c551eaf62de4db15094ce5f2e
+    md5: 3984d9831459b594ab7028fcfce3826a
 work/ice/RESTART/mice.nc-01001231:
   copy: true
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ice/mice.nc-01001231
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/ice/mice.nc-01001231
   hashes:
-    binhash: 86630cac8e3acfb2d69f60a6d0e1e40b
+    binhash: 56cb91d0eaf5568365afcc8a63fe87cf
     md5: 380a7008500f58eb5e8006b1eac18527
 work/ice/RESTART/restart_date.nml:
   copy: true
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ice/restart_date.nml
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/ice/restart_date.nml
   hashes:
-    binhash: 17fac552938796d021d131b8b5c0f191
-    md5: da5f6db5c1b2dac11f27446f21db08cb
+    binhash: 034ab852a9d6f512daa873ca2da7e4a8
+    md5: 358e9d0b902f6f4488e6a7a202fe1751
+work/ocean/INPUT/alk.nc:
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/ocean/alk.nc
+  hashes:
+    binhash: c5b406eb06aa34f516380a7e2635e9b4
+    md5: 0ff81621e949ef73c7660ecb2a9deadb
+work/ocean/INPUT/dic.nc:
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/ocean/dic.nc
+  hashes:
+    binhash: 534f48bc275ba4e8840c6267c98b85c2
+    md5: eafaf68d73a8378fafcdb08bfb181c47
+work/ocean/INPUT/fe.nc:
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/ocean/fe.nc
+  hashes:
+    binhash: d1544e7d2c402253fe8e31ca77bac4bf
+    md5: f1eacfbeeb71c9da9c6bcdaef8048991
+work/ocean/INPUT/no3.nc:
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/ocean/no3.nc
+  hashes:
+    binhash: 1351e629b7b9f33ecbaca3bf48298c73
+    md5: c3255f83e47acabe9040314a0d61d5a2
+work/ocean/INPUT/o2.nc:
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/ocean/o2.nc
+  hashes:
+    binhash: 064cc922510ce0b5e8b567475c9f7e10
+    md5: 5f2b3e7da8c10c1845a1d909905ebc4f
 work/ocean/INPUT/ocean_age.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ocean/ocean_age.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/ocean/ocean_age.res.nc
   hashes:
-    binhash: 73b781f7e79c5382d43c69513e567cb7
-    md5: 5ad601c0eaad3cfc3baa47aed91d1af9
+    binhash: 6923c46f254e2a9cbbb535694d1dad25
+    md5: cabd6a9d79baaa89faaeebaf7d9d0842
 work/ocean/INPUT/ocean_barotropic.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ocean/ocean_barotropic.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/ocean/ocean_barotropic.res.nc
   hashes:
-    binhash: a28a0924b37c8b22d11fdbffe5afc105
-    md5: 97a5f4dc4a379ea4cad9f5d342ed6c51
+    binhash: 2b66c88223ff9dd3d34118be68fe5a95
+    md5: 05d0bebd381223d1928c9acaafbfa1c9
 work/ocean/INPUT/ocean_bih_friction.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ocean/ocean_bih_friction.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/ocean/ocean_bih_friction.res.nc
   hashes:
-    binhash: 57f14885eabee760edbcd5dc03df110c
-    md5: 78ebb71bbf0e28e14d72243cf48a483c
+    binhash: e6b455bb1191c81e248c183a5bf7de7a
+    md5: 0eaf3f3db0a6314920de9bef869dbbed
 work/ocean/INPUT/ocean_density.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ocean/ocean_density.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/ocean/ocean_density.res.nc
   hashes:
-    binhash: 1683d1032fb56b5f0cf63a890db0e0f4
-    md5: 2ea72f188feac5017d4c7456f514e1e6
+    binhash: d875cb959abd587218b2f08741948264
+    md5: 6112506a5925df12808858d3d3249d5e
 work/ocean/INPUT/ocean_frazil.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ocean/ocean_frazil.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/ocean/ocean_frazil.res.nc
   hashes:
-    binhash: 59f983ebd48d8bb4b85e9a12671917bb
-    md5: dfd57082dc58081e9ed6b515f2d8a4c1
+    binhash: 0fa0e6c273ea3cada920fb5977836620
+    md5: 32c2bf696990a5b3248669886d849afc
 work/ocean/INPUT/ocean_lap_friction.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ocean/ocean_lap_friction.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/ocean/ocean_lap_friction.res.nc
   hashes:
-    binhash: 98f2376bee37c48160d09d8d090867b9
-    md5: 2c1dbc74450e72925f9dbe7486689675
+    binhash: 99a3224b2ec82f6e51b013e73190250c
+    md5: e0d25734b91754fd8c1cde9f6bed424a
 work/ocean/INPUT/ocean_neutral.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ocean/ocean_neutral.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/ocean/ocean_neutral.res.nc
   hashes:
-    binhash: b619d96024d81f27c146d5f1aee761a4
-    md5: fab54ae81945add9ae5e850a4569ec34
+    binhash: 072a77adc7fbe826a91052e114eb74b7
+    md5: 4bd8a76bec5a4cbc2659c7b7a8966570
 work/ocean/INPUT/ocean_pot_temp.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ocean/ocean_pot_temp.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/ocean/ocean_pot_temp.res.nc
   hashes:
-    binhash: a5728081144e58008d000ee065410e00
-    md5: dd179d49d13b0b11d524df725b6eec05
+    binhash: 0be12a394c55839f7a01c4b95459ab28
+    md5: 238469bfb83ac0c8ad7a349ee2cabcdb
 work/ocean/INPUT/ocean_sbc.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ocean/ocean_sbc.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/ocean/ocean_sbc.res.nc
   hashes:
-    binhash: fa7eb79171d6283309af858214d8a6d8
-    md5: 655ee14d694588f2cdb870535df0b042
+    binhash: fa37fe01b41b97d131a5240a601437dd
+    md5: b29b90fdd9af3364baaa389b1c4c9a56
 work/ocean/INPUT/ocean_sigma_transport.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ocean/ocean_sigma_transport.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/ocean/ocean_sigma_transport.res.nc
   hashes:
-    binhash: 1eb6035036f07358de1f9a03908d94f6
-    md5: fe527a9917d30955d0dc082271c1392f
+    binhash: efa92cfb166b8c4b44e4a01e02e3b111
+    md5: b0a29b8b2a1d297be1eeaba44b19cb51
 work/ocean/INPUT/ocean_solo.res:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ocean/ocean_solo.res
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/ocean/ocean_solo.res
   hashes:
-    binhash: 612a0d10f3acfcf78d4a5fa9473eb369
-    md5: 354221e55782d6c1ffff3f9c3df24ffd
+    binhash: 36f974070b7611806fa05975f4db7c06
+    md5: 3831d96921f04f55fcdd18dd9bb0f157
 work/ocean/INPUT/ocean_temp_salt.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ocean/ocean_temp_salt.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/ocean/ocean_temp_salt.res.nc
   hashes:
-    binhash: 9f79790fcff30cd2284562045ee319d0
-    md5: cd1b95ef3ac60f9e1f5af29d6bb2d4d5
+    binhash: 522b45c0a128703c1a00fc9595024f2a
+    md5: f2f473690f0df3d6ca1ca7d02f9b9719
 work/ocean/INPUT/ocean_thickness.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ocean/ocean_thickness.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/ocean/ocean_thickness.res.nc
   hashes:
-    binhash: 5d4f9bde26e4554fb34c5b9ea7dac325
-    md5: 5a9bbbca1e6fd2c963db84dda5a84acf
+    binhash: 904f7b6204559b8c4d71330af6f83cb7
+    md5: a85e9c35e642e0f3ecf01a3906c952cc
 work/ocean/INPUT/ocean_tracer.res:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ocean/ocean_tracer.res
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/ocean/ocean_tracer.res
   hashes:
-    binhash: 4219ff58220b565482be8527fba50863
-    md5: 5e5db59b3963b8130ccc76557ed2badc
+    binhash: 5d42d3e9cc0fc5303edefab1d0f6510c
+    md5: 4072d02234d55c26393b6e54e2fd6320
 work/ocean/INPUT/ocean_velocity.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ocean/ocean_velocity.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/ocean/ocean_velocity.res.nc
   hashes:
-    binhash: f63778183617313c83dbecc57619837c
-    md5: 287edec7690400b797b1cbf6e1ea60f0
+    binhash: 84f8523c181f6fa9c33365a00180dc72
+    md5: 157e0165978e5c4771bfdd13d167a543
 work/ocean/INPUT/ocean_velocity_advection.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ocean/ocean_velocity_advection.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/ocean/ocean_velocity_advection.res.nc
   hashes:
-    binhash: 99a342d73a013f4caf0c5e2d11a90a40
-    md5: 653ffae21c9f0a18718d441d591798a1
+    binhash: c964bf9ef61456a7101d04599dd208d1
+    md5: ccdcea5e0a9eb81bb13cc5bf73555632
 work/ocean/INPUT/ocean_wombatlite.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ocean/ocean_wombatlite.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/ocean/ocean_wombatlite.res.nc
   hashes:
-    binhash: 39a911759643281abf7191051a078619
-    md5: 55f4d608998d4e908f645ac96b626224
-work/ocean/INPUT/ocean_wombatlite.res.nc-01001231-v20241210:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ocean/ocean_wombatlite.res.nc-01001231-v20241210
+    binhash: e9e31e014f89ade38dfcecf5bfe4ac8b
+    md5: e3b5526e20f0227495b7375f753ebbee
+work/ocean/INPUT/ocean_wombatlite.res.nc_original:
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/ocean/ocean_wombatlite.res.nc_original
   hashes:
-    binhash: 45a1b096c145110b1b177e667e51c568
-    md5: b1c0623cab6acda07cf0b629110b52c5
-work/ocean/INPUT/ocean_wombatlite.res.nc-01001231-v20241211:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ocean/ocean_wombatlite.res.nc-01001231-v20241211
+    binhash: 11d3e16f45bd7d5f808382e31d531a14
+    md5: 692bb0484be9fa36c7610b143f9635b2
+work/ocean/INPUT/ocean_wombatlite_airsea_flux.res.nc:
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/ocean/ocean_wombatlite_airsea_flux.res.nc
   hashes:
-    binhash: ecf161044653c537ac13002ef5d188b0
-    md5: 951d801f3cc201f0c71aa88c367bed24
-work/ocean/INPUT/ocean_wombatlite.res.nc-01001231-v20241211-2:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.02.17/ocean/ocean_wombatlite.res.nc-01001231-v20241211-2
-  hashes:
-    binhash: fdb90b2959114ffed3c86ce4ba884e0f
-    md5: 55f4d608998d4e908f645ac96b626224
+    binhash: 6e5f12adfca1759d53abd1a34d716024
+    md5: 0ce7f581bc697c2f87f1ffc6de3e5779


### PR DESCRIPTION
Closes #86.

This PR points the `dev-preindustrial+concentrations` configuration to the new restart for the next spinup simulation. 

The new restart is located at `/g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08`, and has been created as follows:

1. The `ocean`, `ice`, and `coupler` directories were copied from `/scratch/p66/pjb581/access-esm/archive/pi_concentrations_test3-restart-840-35bbe5a7/backup_restart061`. My understanding is that this restart comes from the long ocean spinup, and the bgc restart `/ocean/ocean_wombatlite.res.nc` has been altered with deep tracer values reset to the original values from `/g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2024.12.10/ocean/ocean_wombatlite.res.nc`
2. The `atmosphere` directory was copied from `/scratch/p66/jxs599/access-esm/archive/MarchEpot-preindustrial-sapphire-rapids-9d8695c2/restart030`. This comes from a run which includes more recent CABLE updates.
3. Restart dates for all components were reset to year 101. This was done using a modified version of the [`set_restart_year.sh` script](https://gist.github.com/blimlim/1f103fbe8fac57e4176d1e094522a2f9#file-set_restart_year-sh) from the ESM1.5 warm restart scripts. This specifically:
   - Set the year to 101 in `ocean/ocean_solo.res`, `atmosphere/um_res.yaml`, `ice/restart_date.nml`
   - Update the UM year in the `restart_dump.astart` file via the [update_um_year.py](https://gist.github.com/blimlim/1f103fbe8fac57e4176d1e094522a2f9#file-update_um_year-py) script.
   - Set the time unit to start at year 101 in `ice/mice.nc`
   - Set the previous simulated time (ie. seconds since `init_date`) to 0 in the binary `ice/iced.YYYYMMDD` restart file.



