### PR TITLE
`dev-preindustrial+concentrations`: test MOM5 CMake

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -30,7 +30,7 @@ modules:
   use:
       - /g/data/vk83/prerelease/modules
   load:
-      - access-esm1p6/pr86-2
+      - access-esm1p6/pr86-4
 
 # Model configuration
 model: access-esm1.6

--- a/config.yaml
+++ b/config.yaml
@@ -30,7 +30,7 @@ modules:
   use:
       - /g/data/vk83/prerelease/modules
   load:
-      - access-esm1p6/pr86-4
+      - access-esm1p6/pr86-5
 
 # Model configuration
 model: access-esm1.6

--- a/config.yaml
+++ b/config.yaml
@@ -30,7 +30,7 @@ modules:
   use:
       - /g/data/vk83/prerelease/modules
   load:
-      - access-esm1p6/pr86-5
+      - access-esm1p6/pr86-8
 
 # Model configuration
 model: access-esm1.6

--- a/config.yaml
+++ b/config.yaml
@@ -28,9 +28,9 @@ platform:
 # Modules for loading model executables
 modules:
   use:
-      - /g/data/vk83/modules
+      - /g/data/vk83/prerelease/modules
   load:
-      - access-esm1p6/dev_2025.04.000
+      - access-esm1p6/pr86-2
 
 # Model configuration
 model: access-esm1.6
@@ -72,7 +72,7 @@ submodels:
     - name: ocean
       model: mom
       ncpus: 196
-      exe: fms_ACCESS-ESM.x
+      exe: mom5_access_cm
       input:
         # Biogeochemistry
         - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/biogeochemistry/global.1deg/2020.05.19/dust.nc
@@ -138,11 +138,12 @@ runspersub: 1
 # Misc
 restart_freq: 10YS
 
-runlog: true
+runlog: False
 manifest:
   reproduce:
-    exe: true
-
+    exe: False
+metadata:
+  enable: False
 
 stacksize: unlimited
 qsub_flags: -W umask=027

--- a/manifests/exe.yaml
+++ b/manifests/exe.yaml
@@ -12,7 +12,7 @@ work/ice/cice_access_360x300_12x1_12p.exe:
     binhash: 50cb86171d206799c2080f831e9721c3
     md5: 655f37ac8823853aaa98818888150134
 work/ocean/mom5_access_cm:
-  fullpath: /g/data/vk83/prerelease/apps/spack/0.22/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/mom5-git.51f67bf4a554d62f7b1ce99caf2f39dc1ef6b7b3_access-esm1.6-6fs4qa2biamiiamgzjnggfkxkkvz3e73/bin/mom5_access_cm
+  fullpath: /g/data/vk83/prerelease/apps/spack/0.22/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/mom5-git.fcb3b49d389dcf36a6b0c7c0a9394c81a1170ee4_access-esm1.6-gva7jtp6izlsnsiay43taq4s6uu6ytix/bin/mom5_access_cm
   hashes:
-    binhash: 95319765d55963009f97a6dc74eafa20
-    md5: 8acfa93d99672ed09a8eefeb7179275f
+    binhash: 0023e1954eb44604a519531ab00a5b0a
+    md5: 405d3da6e76162f4542d10302e6fae77

--- a/manifests/exe.yaml
+++ b/manifests/exe.yaml
@@ -12,7 +12,7 @@ work/ice/cice_access_360x300_12x1_12p.exe:
     binhash: 50cb86171d206799c2080f831e9721c3
     md5: 655f37ac8823853aaa98818888150134
 work/ocean/mom5_access_cm:
-  fullpath: /g/data/vk83/prerelease/apps/spack/0.22/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/mom5-git.1fdf6ffe8098189e159f8daae93c3b8a66c12add_access-esm1.6-oweawljcaibrxvevmsatchedjwikv3h6/bin/mom5_access_cm
+  fullpath: /g/data/vk83/prerelease/apps/spack/0.22/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/mom5-git.51f67bf4a554d62f7b1ce99caf2f39dc1ef6b7b3_access-esm1.6-6fs4qa2biamiiamgzjnggfkxkkvz3e73/bin/mom5_access_cm
   hashes:
-    binhash: 0546514ee7a01b89c9ae20e92cf5f7a7
-    md5: 595841226384d76a473a70cbbc992df7
+    binhash: 95319765d55963009f97a6dc74eafa20
+    md5: 8acfa93d99672ed09a8eefeb7179275f

--- a/manifests/exe.yaml
+++ b/manifests/exe.yaml
@@ -2,17 +2,17 @@ format: yamanifest
 version: 1.0
 ---
 work/atmosphere/um_hg3.exe:
-  fullpath: /g/data/vk83/apps/spack/0.22/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/um7-git.access-esm1.6-2025.04.000_access-esm1.6-fxsz3eegxziq4s42vpabhamy2tdzubwf/bin/um_hg3.exe
+  fullpath: /g/data/vk83/prerelease/apps/spack/0.22/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/um7-git.access-esm1.6-2025.04.000_access-esm1.6-fxsz3eegxziq4s42vpabhamy2tdzubwf/bin/um_hg3.exe
   hashes:
-    binhash: 522c6b8653d3645be8e2d1686644b1d8
-    md5: d0d4230cba649b578e63df5dcdb93d9e
+    binhash: c918e27de47fb554c8bc425a7ed588c0
+    md5: ddd94b2a3dac20570c80637123c8fb18
 work/ice/cice_access_360x300_12x1_12p.exe:
-  fullpath: /g/data/vk83/apps/spack/0.22/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/cice4-git.access-esm1.6-2025.04.000_access-esm1.5-ehk25va4ib5ohs7puldvht6mcdnxo3sl/bin/cice_access_360x300_12x1_12p.exe
+  fullpath: /g/data/vk83/prerelease/apps/spack/0.22/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/cice4-git.access-esm1.6-2025.04.000_access-esm1.5-ehk25va4ib5ohs7puldvht6mcdnxo3sl/bin/cice_access_360x300_12x1_12p.exe
   hashes:
-    binhash: 2e2e2f1aa48c23a5a61732faa86eddc2
-    md5: 67b8c14d69aa2b22dfb2e543d5c9167b
-work/ocean/fms_ACCESS-ESM.x:
-  fullpath: /g/data/vk83/apps/spack/0.22/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/mom5-git.dev-2025.03.001_access-esm1.6-dhww7jgsd5oskneizdumsuzspgabogq6/bin/fms_ACCESS-ESM.x
+    binhash: 50cb86171d206799c2080f831e9721c3
+    md5: 655f37ac8823853aaa98818888150134
+work/ocean/mom5_access_cm:
+  fullpath: /g/data/vk83/prerelease/apps/spack/0.22/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/mom5-git.1fdf6ffe8098189e159f8daae93c3b8a66c12add_access-esm1.6-oweawljcaibrxvevmsatchedjwikv3h6/bin/mom5_access_cm
   hashes:
-    binhash: d41a3ca60d1b2b33e003741d51897c50
-    md5: d82d6e1cbc1fd21d6de111a6122c94d7
+    binhash: 0546514ee7a01b89c9ae20e92cf5f7a7
+    md5: 595841226384d76a473a70cbbc992df7

--- a/manifests/exe.yaml
+++ b/manifests/exe.yaml
@@ -12,7 +12,7 @@ work/ice/cice_access_360x300_12x1_12p.exe:
     binhash: 50cb86171d206799c2080f831e9721c3
     md5: 655f37ac8823853aaa98818888150134
 work/ocean/mom5_access_cm:
-  fullpath: /g/data/vk83/prerelease/apps/spack/0.22/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/mom5-git.fcb3b49d389dcf36a6b0c7c0a9394c81a1170ee4_access-esm1.6-gva7jtp6izlsnsiay43taq4s6uu6ytix/bin/mom5_access_cm
+  fullpath: /g/data/vk83/prerelease/apps/spack/0.22/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/mom5-git.2025.05.000_access-esm1.6-p3u6e7uchqy4yrxuimbu4izlck43ie4f/bin/mom5_access_cm
   hashes:
-    binhash: 0023e1954eb44604a519531ab00a5b0a
-    md5: 405d3da6e76162f4542d10302e6fae77
+    binhash: d19482e3fc7377168334715ccb072966
+    md5: 2a26d9bea055ed7173bed6d0648e6e3e

--- a/manifests/restart.yaml
+++ b/manifests/restart.yaml
@@ -15,20 +15,20 @@ work/coupler/a2i.nc:
   copy: true
   fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/coupler/a2i.nc
   hashes:
-    binhash: 3e225c23a5e0f6d6dae8ec7fae51739d
-    md5: 19f07ed3d650fe59f8ef0c924b158c7b
+    binhash: c63c61396460084683eabb9a34237bc9
+    md5: 1e30dea430b439d41fdb6adb6f058f82
 work/coupler/i2a.nc:
   copy: true
   fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/coupler/i2a.nc
   hashes:
-    binhash: 62cfcaaf65941215882355a2a070b24e
-    md5: 1eb74ae43c42902b2428008fe4862eb0
+    binhash: b9753ebee69797fb81c49f142453c2e9
+    md5: 156a6b093fe938145d33f2bc40512af1
 work/coupler/o2i.nc:
   copy: true
   fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/coupler/o2i.nc
   hashes:
-    binhash: 6ba525fc18cade8517fd4341e81fd536
-    md5: 9b2b1f77c89e82d6aef4b0a8cdaac91f
+    binhash: 8711cfe1805f17f0380b72a0ee11928a
+    md5: 0cf886ebde653bb3a044fed327d116b2
 work/ice/RESTART/cice_in.nml:
   copy: true
   fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/ice/cice_in.nml


### PR DESCRIPTION
**DO NOT MERGE**

This is a companion PR to https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/86 to test ACCESS-ESM1.6 using the [new MOM5 CMake build system](https://github.com/ACCESS-NRI/MOM5/pull/39) and associated changes.