### PR TITLE
Update phenology file

### DIFF
--- a/atmosphere/cable.nml
+++ b/atmosphere/cable.nml
@@ -62,5 +62,5 @@
 ! filenames for CASA-CNP input files
 ! updated pftlookup file for CABLE3 format
   casafile%cnpbiome='INPUT/pftlookup_cable3.csv'  ! biome specific BGC parameters
-  casafile%phen='INPUT/modis_phenology_csiro.txt' ! phenology by latitude (modis derived)
+  casafile%phen='INPUT/modis_phenology_csiro_nophase.txt' ! phenology by latitude (modis derived)
 &end

--- a/config.yaml
+++ b/config.yaml
@@ -28,9 +28,9 @@ platform:
 # Modules for loading model executables
 modules:
   use:
-      - /g/data/vk83/modules
+      - /g/data/vk83/prerelease/modules
   load:
-      - access-esm1p6/dev_2025.04.000
+      - access-esm1p6/pr93-1
 
 # Model configuration
 model: access-esm1.6
@@ -56,7 +56,7 @@ submodels:
         - /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/atmosphere/land/biogeochemistry/global.N96/2020.05.19/Ndep_1850_ESM1.anc
         - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/land/soiltype/global.N96/2020.05.19/qrparm.soil_igbp_vg
         - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/land/vegetation/global.N96/2020.05.19/cable_vegfunc_N96.anc
-        - /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/land/biogeochemistry/resolution_independent/2020.05.19/modis_phenology_csiro.txt
+        - /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/land/biogeochemistry/resolution_independent/2025.06.06/modis_phenology_csiro_nophase.txt 
         - /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/land/biogeochemistry/resolution_independent/2024.12.18/pftlookup_cable3.csv
         - /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/land/biogeophysics/resolution_independent/2020.05.19/def_soil_params.txt
         - /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/land/biogeophysics/resolution_independent/2020.05.19/def_veg_params.txt

--- a/config.yaml
+++ b/config.yaml
@@ -56,7 +56,7 @@ submodels:
         - /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/atmosphere/land/biogeochemistry/global.N96/2020.05.19/Ndep_1850_ESM1.anc
         - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/land/soiltype/global.N96/2020.05.19/qrparm.soil_igbp_vg
         - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/land/vegetation/global.N96/2020.05.19/cable_vegfunc_N96.anc
-        - /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/land/biogeochemistry/resolution_independent/2025.06.06/modis_phenology_csiro_nophase.txt 
+        - /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/land/biogeochemistry/resolution_independent/2025.06.06/modis_phenology_csiro_nophase.txt
         - /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/land/biogeochemistry/resolution_independent/2024.12.18/pftlookup_cable3.csv
         - /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/land/biogeophysics/resolution_independent/2020.05.19/def_soil_params.txt
         - /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/land/biogeophysics/resolution_independent/2020.05.19/def_veg_params.txt

--- a/config.yaml
+++ b/config.yaml
@@ -28,9 +28,9 @@ platform:
 # Modules for loading model executables
 modules:
   use:
-      - /g/data/vk83/prerelease/modules
+      - /g/data/vk83/modules
   load:
-      - access-esm1p6/pr93-1
+      - access-esm1p6/dev_2025.06.000
 
 # Model configuration
 model: access-esm1.6

--- a/manifests/exe.yaml
+++ b/manifests/exe.yaml
@@ -2,10 +2,10 @@ format: yamanifest
 version: 1.0
 ---
 work/atmosphere/um_hg3.exe:
-  fullpath: /g/data/vk83/apps/spack/0.22/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/um7-git.access-esm1.6-2025.04.000_access-esm1.6-fxsz3eegxziq4s42vpabhamy2tdzubwf/bin/um_hg3.exe
+  fullpath: /g/data/vk83/apps/spack/0.22/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/um7-git.access-esm1.6-2025.06.000_access-esm1.6-eqtlwbkbfqe5dl4fysji4uatbe3k5cfg/bin/um_hg3.exe
   hashes:
-    binhash: 522c6b8653d3645be8e2d1686644b1d8
-    md5: d0d4230cba649b578e63df5dcdb93d9e
+    binhash: de48b736ea1d61b8c33b4fa9050a7217
+    md5: 1b0f226bd4dcb630b8056315642ae484
 work/ice/cice_access_360x300_12x1_12p.exe:
   fullpath: /g/data/vk83/apps/spack/0.22/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/cice4-git.access-esm1.6-2025.04.000_access-esm1.5-ehk25va4ib5ohs7puldvht6mcdnxo3sl/bin/cice_access_360x300_12x1_12p.exe
   hashes:

--- a/manifests/input.yaml
+++ b/manifests/input.yaml
@@ -1,16 +1,16 @@
 format: yamanifest
 version: 1.0
 ---
-work/atmosphere/INPUT/BC_hi_1850_ESM1.anc:
-  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/atmosphere/aerosol/global.N96/2020.05.19/BC_hi_1850_ESM1.anc
+work/atmosphere/INPUT/BC_1850_cmip7.anc:
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/atmosphere/aerosol/global.N96/2025.06.04/BC_1850_cmip7.anc
   hashes:
-    binhash: a98741eb50f16483786933e6bbd700e3
-    md5: 74803eb36a358f9ac8ecdae36cdb7f56
-work/atmosphere/INPUT/Bio_1850_ESM1.anc:
-  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/atmosphere/aerosol/global.N96/2020.05.19/Bio_1850_ESM1.anc
+    binhash: 1b813f612ec0c46bddb8d1c41dc4cc46
+    md5: 72eac6922e418ad1da3756cd118c80b2
+work/atmosphere/INPUT/Bio_1850_cmip7.anc:
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/atmosphere/aerosol/global.N96/2025.06.04/Bio_1850_cmip7.anc
   hashes:
-    binhash: 4ee80aefae4975731a21667b5b26343f
-    md5: 69dc6afb4bc7524d346f3b82f2657c97
+    binhash: 89287284b946f3165d2d0d0517572e50
+    md5: 9c7af32c6d35a0ecbaa99026bd57943f
 work/atmosphere/INPUT/DMS_conc.N96:
   fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/DMS_conc.N96
   hashes:
@@ -21,11 +21,11 @@ work/atmosphere/INPUT/Ndep_1850_ESM1.anc:
   hashes:
     binhash: 47374849ef42f83e3c02629827a482ee
     md5: 48462cfa1aeed200c3b8d0bf1b49654a
-work/atmosphere/INPUT/OCFF_1850_ESM1.anc:
-  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/atmosphere/aerosol/global.N96/2020.05.19/OCFF_1850_ESM1.anc
+work/atmosphere/INPUT/OCFF_1850_cmip7.anc:
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/atmosphere/aerosol/global.N96/2025.06.04/OCFF_1850_cmip7.anc
   hashes:
-    binhash: 0ec3fde7a17984009b8d90ff1ddbc92f
-    md5: 95eec04860fa30ee863d30e67e683407
+    binhash: 7ac76d91223e2e1cab68c331ad7b6547
+    md5: 6bceddebc7b0c2ebeea3be8b4c0f13e8
 work/atmosphere/INPUT/STASHmaster/STASHmaster_A:
   fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/STASHmaster/STASHmaster_A
   hashes:
@@ -76,11 +76,11 @@ work/atmosphere/INPUT/def_veg_params.txt:
   hashes:
     binhash: 22ce1f400a832868aefeaa9721ac3a48
     md5: 1f9a27f0e252bf6c466100573c126789
-work/atmosphere/INPUT/modis_phenology_csiro.txt:
-  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/land/biogeochemistry/resolution_independent/2020.05.19/modis_phenology_csiro.txt
+work/atmosphere/INPUT/modis_phenology_csiro_nophase.txt:
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/land/biogeochemistry/resolution_independent/2025.06.06/modis_phenology_csiro_nophase.txt
   hashes:
-    binhash: a86ffb366359d6d353c6f385789185a1
-    md5: a7b89d25cff82cf13cf812a98ad3a029
+    binhash: fa3895eef407ca32fdd36817452f75b8
+    md5: 490d889ddfed508c6cfe3d62a225384e
 work/atmosphere/INPUT/ozone_1850_ESM1.anc:
   fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/atmosphere/forcing/global.N96/2020.05.19/ozone_1850_ESM1.anc
   hashes:
@@ -101,11 +101,11 @@ work/atmosphere/INPUT/qrparm.soil_igbp_vg:
   hashes:
     binhash: 51560dde970f7123a7250cc6bdc8f3ef
     md5: 26ce57f462dd574fe49f290ab7877112
-work/atmosphere/INPUT/scycl_1850_ESM1_v4.anc:
-  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/atmosphere/aerosol/global.N96/2020.05.19/scycl_1850_ESM1_v4.anc
+work/atmosphere/INPUT/scycl_1850_cmip7.anc:
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/atmosphere/aerosol/global.N96/2025.06.04/scycl_1850_cmip7.anc
   hashes:
-    binhash: 4dac8b00fc0b26a086f2dd9e610aba6a
-    md5: 2c390f44c4f57078340cfbd408fdc754
+    binhash: a338723ccb4fd879c443516e844c7198
+    md5: 46c41f2683230a383bd7fb1face49203
 work/atmosphere/INPUT/spec3a_lw_hadgem1_6on:
   fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_lw_hadgem1_6on
   hashes:

--- a/manifests/restart.yaml
+++ b/manifests/restart.yaml
@@ -15,20 +15,20 @@ work/coupler/a2i.nc:
   copy: true
   fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/coupler/a2i.nc
   hashes:
-    binhash: 3e225c23a5e0f6d6dae8ec7fae51739d
-    md5: 19f07ed3d650fe59f8ef0c924b158c7b
+    binhash: c63c61396460084683eabb9a34237bc9
+    md5: 1e30dea430b439d41fdb6adb6f058f82
 work/coupler/i2a.nc:
   copy: true
   fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/coupler/i2a.nc
   hashes:
-    binhash: 62cfcaaf65941215882355a2a070b24e
-    md5: 1eb74ae43c42902b2428008fe4862eb0
+    binhash: b9753ebee69797fb81c49f142453c2e9
+    md5: 156a6b093fe938145d33f2bc40512af1
 work/coupler/o2i.nc:
   copy: true
   fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/coupler/o2i.nc
   hashes:
-    binhash: 6ba525fc18cade8517fd4341e81fd536
-    md5: 9b2b1f77c89e82d6aef4b0a8cdaac91f
+    binhash: 8711cfe1805f17f0380b72a0ee11928a
+    md5: 0cf886ebde653bb3a044fed327d116b2
 work/ice/RESTART/cice_in.nml:
   copy: true
   fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.04.08/ice/cice_in.nml


### PR DESCRIPTION
Closes preindustrial half of #109 (AMIP changes to follow).

This PR points the configuration to the updated phenology file, allowing the number of phenology types to be read from the file rather than hardcoded. 

Also includes changes to input manifests which were skipped in #131.