### PR TITLE
Add umask option for netCDF conversion

### DIFF
--- a/scripts/NetCDF-conversion/UM_conversion_job.sh
+++ b/scripts/NetCDF-conversion/UM_conversion_job.sh
@@ -5,6 +5,7 @@
 #PBS -q normal
 #PBS -l walltime=00:40:00
 #PBS -l wd
+#PBS -W umask=027
 
 module use /g/data/vk83/modules
 module load payu


### PR DESCRIPTION
Closes preindustrial+concentrations section of #148. Adds umask option so that conversion logs are group readable.

Permissions after the change:
```
ls -l UM_conversion_job.sh.*
-rw-r----- 1 sw6175 tm70 1814 Jul  8 11:57 UM_conversion_job.sh.e144811826
-rw-r----- 1 sw6175 tm70 1262 Jul  8 11:57 UM_conversion_job.sh.o144811826
```
