### PR TITLE
CMIP7 solar and volcanic forcing update to dev-cmip7-preindustrial+concentrations

### DIFF
--- a/atmosphere/input_atm.nml
+++ b/atmosphere/input_atm.nml
@@ -1,9 +1,9 @@
 &coupling
  access_tfs=-1.8
  xfactor=1.0
- SC=1361.62
+ SC=1361.617
  co2_init=284.725
- VOLCTS_val=138.0
+ VOLCTS_val=137.31
  ocn_sss=.false.
  sdump_enable=.false.
  rdump_enable=.false.


### PR DESCRIPTION
Update the ESM1.6 pre-industrial configuration to match the CMIP7 forcings as per the [u-dq819/trunk@331487](https://code.metoffice.gov.uk/trac/roses-u/browser/d/q/8/1/9/trunk?rev=331487&order=name) CMIP7 ancillary suite for ACCESS-ESM1.6, run as per `gadi:/scratch/tm70/pcl851/cylc-run/u-dq819.trunk/run20`.

The [CMIP7 pre-industrial forcing datasets](https://input4mips-cvs.readthedocs.io/en/latest/dataset-overviews/) [included](https://code.metoffice.gov.uk/trac/roses-u/browser/d/q/8/1/9/trunk/rose-suite.conf?rev=331487) are:

6. [Stratospheric volcanic SO2 emissions and aerosol optical properties](https://input4mips-cvs.readthedocs.io/en/latest/dataset-overviews/stratospheric-volcanic-so2-emissions-aod/)
UOEXETER-CMIP-2-2-1

9. [Solar](https://input4mips-cvs.readthedocs.io/en/latest/dataset-overviews/solar/)
SOLARIS-HEPPA-CMIP-4-6