### PR TITLE
test-PIspinup-Sept-C

### DIFF
--- a/atmosphere/input_atm.nml
+++ b/atmosphere/input_atm.nml
@@ -7,4 +7,5 @@
  ocn_sss=.false.
  sdump_enable=.false.
  rdump_enable=.false.
+ ocean_albedo_factor=0.92
 &end

--- a/config.yaml
+++ b/config.yaml
@@ -16,7 +16,7 @@
 # Note: if laboratory is relative path, it is relative to shortpath/$USER
 laboratory: access-esm
 
-jobname: pre-industrial
+jobname: test-PIspinup-Sept-C
 queue: normalsr
 walltime: 2:30:00
 jobfs: 1500MB
@@ -119,7 +119,7 @@ submodels:
 collate:
     enable: false
 
-restart: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26
+restart: /g/data/p66/jxs599/ESM16/PAYU/Feat/feat-Sept-C/restart300 
 
 # Timing controls
 calendar:

--- a/manifests/restart.yaml
+++ b/manifests/restart.yaml
@@ -2,138 +2,138 @@ format: yamanifest
 version: 1.0
 ---
 work/atmosphere/restart_dump.astart:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26/atmosphere/restart_dump.astart
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26.B/atmosphere/restart_dump.astart
   hashes:
-    binhash: eeebd0571fe00ea95219c1271c181992
-    md5: d1c33af7ee7609f049c4ad2ab37adbe0
+    binhash: 81c75f027ed1fdd9e2a34d673cf58986
+    md5: e013ca06e1d0acc356967e9f72d5a79c
 work/atmosphere/um.res.yaml:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26/atmosphere/um.res.yaml
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26.B/atmosphere/um.res.yaml
   hashes:
-    binhash: b79747f8d84be69b6264ed0a559bee99
-    md5: 34ede0cf869d6dcb320c68f6ea8a49bd
+    binhash: 50b91208018e9cfca9443f31c7a3cfcd
+    md5: 7828ba45a80acabc27e968b82818b441
 work/coupler/a2i.nc:
   copy: true
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26/coupler/a2i.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26.B/coupler/a2i.nc
   hashes:
-    binhash: cde99fc41b62ee73fc5377c60a90ba5a
-    md5: b821afb1bd641716401a07f1299f0119
+    binhash: 1434b85144697c2b9de635b287e00f58
+    md5: 6bb9db13d98f73bb28ffabad460c81e0
 work/coupler/i2a.nc:
   copy: true
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26/coupler/i2a.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26.B/coupler/i2a.nc
   hashes:
-    binhash: fc073c49912917d3773b52dd7469081a
-    md5: b1bfe46e8f56919656b4390d6060a343
+    binhash: f706caf59e64ee23e30ed8382569aa9c
+    md5: ba75b92ad045e431fca08c66e721044b
 work/coupler/o2i.nc:
   copy: true
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26/coupler/o2i.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26.B/coupler/o2i.nc
   hashes:
-    binhash: b05d14286b6b26323b3f7af304c71d3b
-    md5: edb8e7c49aa090785de8b79c021ba371
+    binhash: 65b4ec42d1667d53acb0be4d9cb303de
+    md5: 73f56c64878bd2e74b156508eddbd3fe
 work/ice/RESTART/ice.restart_file:
   copy: true
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26/ice/ice.restart_file
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26.B/ice/ice.restart_file
   hashes:
-    binhash: 9d563fbce9e6626d81fbf8c6e64aec52
-    md5: f81ab888a69b3da2d919d4e1ccc0c26b
-work/ice/RESTART/iced.1843-01-01-00000.nc:
+    binhash: d4be4e98453a964689464c345d93611c
+    md5: 72352ef6c98171ab3679d2a419575d57
+work/ice/RESTART/iced.1092-01-01-00000.nc:
   copy: true
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26/ice/iced.1843-01-01-00000.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26.B/ice/iced.1092-01-01-00000.nc
   hashes:
-    binhash: 0a4267658d15d8435aa661478cde1f94
-    md5: 05aa2ac03727e0c66b610c9e5680406f
+    binhash: 447d8e7a1dc7c54174597d29b772da2c
+    md5: 47f1fd567ce62f5ab46b65e318830af2
 work/ice/RESTART/mice.nc:
   copy: true
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26/ice/mice.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26.B/ice/mice.nc
   hashes:
-    binhash: 1dc8e018dd970700bb1e9d32c5aff0ee
+    binhash: 9ea18951691290d94217e2504c0d5be6
     md5: a4a74c30b58995b04e483416e345c8fc
 work/ocean/INPUT/ocean_age.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26/ocean/ocean_age.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26.B/ocean/ocean_age.res.nc
   hashes:
-    binhash: fe28d3b8c3b0b03866e7b5a1c9610dce
-    md5: df7da785860d0b56b618ebc7e382f76a
+    binhash: 85112fcf745369db3eae080450ffd6e6
+    md5: bca226afcd93e720da2d88538dbfa76c
 work/ocean/INPUT/ocean_barotropic.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26/ocean/ocean_barotropic.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26.B/ocean/ocean_barotropic.res.nc
   hashes:
-    binhash: 9bb750d40eaf588bec0b2e4348ba2643
-    md5: c41091e8d30d54605435de71aba98267
+    binhash: 35eabcc5ad68f9d2efd2b9d4ee75b073
+    md5: 0a6da428050811bdebf9607e64dca0ce
 work/ocean/INPUT/ocean_bih_friction.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26/ocean/ocean_bih_friction.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26.B/ocean/ocean_bih_friction.res.nc
   hashes:
-    binhash: 6c3ae69e0ec9abee2ae459d7df5eca1c
-    md5: e404c8f275b9dd4230358952fbbda2c7
+    binhash: 7a886388e645251a1879bab3ceddf197
+    md5: 170e7fbe05b79257d81847a5cd6ee6fd
 work/ocean/INPUT/ocean_density.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26/ocean/ocean_density.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26.B/ocean/ocean_density.res.nc
   hashes:
-    binhash: 6787ca3c85aa402a79b2ffe0335f6f28
-    md5: a3017928f447db2eaa8f1131570aa399
+    binhash: 4ac0ddaca816ac94f8a4263d8d577ad0
+    md5: f2de5ddacd426fff63c57714c422c3a5
 work/ocean/INPUT/ocean_frazil.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26/ocean/ocean_frazil.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26.B/ocean/ocean_frazil.res.nc
   hashes:
-    binhash: d4db4c6e2288ad582ac547dd18e3d302
-    md5: d7358cbc54f99fecd9f9535397d2d3d1
+    binhash: a08ca6f928b8536a3da40155b68678f9
+    md5: a1c87104ced0cb1a92f70d61fa795b13
 work/ocean/INPUT/ocean_lap_friction.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26/ocean/ocean_lap_friction.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26.B/ocean/ocean_lap_friction.res.nc
   hashes:
-    binhash: 42bea2595b64dc9d0e8f3c896544a98d
-    md5: 0094f5c181a91943258b2dba294dfe20
+    binhash: b0f5582184394f71e96c9b6ddb7b760f
+    md5: d724e37f2c282c9205f3cfe6f9f978da
 work/ocean/INPUT/ocean_neutral.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26/ocean/ocean_neutral.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26.B/ocean/ocean_neutral.res.nc
   hashes:
-    binhash: 8ab3f32542b17ebc87506d526fa33dfe
-    md5: a7913a457a1c3250b5cca86ba4b12f64
+    binhash: 4b5f4b147364080bf6eec8605faee3e2
+    md5: 06ab820275282b5854e30d8106e073d9
 work/ocean/INPUT/ocean_pot_temp.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26/ocean/ocean_pot_temp.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26.B/ocean/ocean_pot_temp.res.nc
   hashes:
-    binhash: 71aa275eb7dd937310107f8beb1aa60f
-    md5: 11d0852a7320146c00c7eaf678e2819f
+    binhash: 208ad7b0a215435426c02588b2f01182
+    md5: 9cf32a1209fd613b8e463fb6274a7d04
 work/ocean/INPUT/ocean_sbc.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26/ocean/ocean_sbc.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26.B/ocean/ocean_sbc.res.nc
   hashes:
-    binhash: d0c9a3bb87c30be58d2c85044bb40cea
-    md5: 510e182779435153a0603122e154aeac
+    binhash: fcbc0e1b4ad6d5106c8fa5a2e6db6ca8
+    md5: fef6d633cc8bec86d4e28c0f3d608bff
 work/ocean/INPUT/ocean_sigma_transport.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26/ocean/ocean_sigma_transport.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26.B/ocean/ocean_sigma_transport.res.nc
   hashes:
-    binhash: 5da9ee32d53020e24d176bb8c8f2fa43
+    binhash: 54ef9a9865bf398d1a2e544f08ae73bc
     md5: e79fdeb47e6d0f7d20847a1ded2b5296
 work/ocean/INPUT/ocean_solo.res:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26/ocean/ocean_solo.res
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26.B/ocean/ocean_solo.res
   hashes:
-    binhash: b010edc54b9a8e4394521f77e4b93b7f
-    md5: 710d8ee95f3aa1f03768ab02a8412b00
+    binhash: d6e32bcde4960386852424376282224a
+    md5: 79d643aecd75e56766b80e4218b19d23
 work/ocean/INPUT/ocean_temp_salt.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26/ocean/ocean_temp_salt.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26.B/ocean/ocean_temp_salt.res.nc
   hashes:
-    binhash: 28a9343349363c95d56ccf4bf4a0d32e
-    md5: a6d45cd3c74b46003ab4f0cada678c33
+    binhash: 5aff0378516f592011622a06f8b05a28
+    md5: a657409ab58fdefe7f78e298b7c8ac69
 work/ocean/INPUT/ocean_thickness.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26/ocean/ocean_thickness.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26.B/ocean/ocean_thickness.res.nc
   hashes:
-    binhash: 507221c9def6670ba2644ad72df77197
-    md5: 652d1abb7b7614c7356788680d0368ef
+    binhash: b1311985f58b70dabe75f8fa221e5074
+    md5: f7f480adeeb03d868d82312864576575
 work/ocean/INPUT/ocean_tracer.res:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26/ocean/ocean_tracer.res
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26.B/ocean/ocean_tracer.res
   hashes:
-    binhash: 0baff03e985ee657615382306cf5ef92
-    md5: 7c2fe1b221d1a8fd2a28fdbb41d1ac20
+    binhash: 7e0be70adf407479822c74b0c4759e3b
+    md5: 4aaa0f49b8c082fd9915ae98a688c2ea
 work/ocean/INPUT/ocean_velocity.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26/ocean/ocean_velocity.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26.B/ocean/ocean_velocity.res.nc
   hashes:
-    binhash: c04de7e5d9c254c23da2ca13c58b3206
-    md5: 9349b1f8116b542755b7db7f04c07f0c
+    binhash: db9f4fdd3285009bbb5703cb320c7653
+    md5: 43532a2fa2fed1c0a4b15c09e77337a1
 work/ocean/INPUT/ocean_velocity_advection.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26/ocean/ocean_velocity_advection.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26.B/ocean/ocean_velocity_advection.res.nc
   hashes:
-    binhash: 45f39688d6d3f53f2044009381889b71
-    md5: 7011db55e843f8836e3316af42e2e059
+    binhash: fca2e4362139c9f61129e920d37a17ff
+    md5: 840e8dc9f4b7d7f7fd0dae5f3f521959
 work/ocean/INPUT/ocean_wombatlite.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26/ocean/ocean_wombatlite.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26.B/ocean/ocean_wombatlite.res.nc
   hashes:
-    binhash: 68a3f22cdd55d223d796aa48febe6820
-    md5: 04ab26d694b27896340a8535f18b70be
+    binhash: f13b0566f9dad2c3a959319d0fe31951
+    md5: a07f600248a73a1fa435e1fb186d980f
 work/ocean/INPUT/ocean_wombatlite_airsea_flux.res.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26/ocean/ocean_wombatlite_airsea_flux.res.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/restart/2025.09.26.B/ocean/ocean_wombatlite_airsea_flux.res.nc
   hashes:
-    binhash: ca9b70100547543ff2f4b10408724476
-    md5: 3c41d58e2f09a28754bccff87e7aeeeb
+    binhash: 45f9b1f89e2d69c83035a5a2e6af5a8c
+    md5: e3fbc57a3beab75c14dc83b96d9c15b0

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,6 @@
-contact: Add your name here
-email: Add your email address here
-created: Add the date you started the experiment here (YYYY-MM-DD)
+contact: Srbinovsky, Jhan (O&A, Aspendale)
+email: Jhan.Srbinovsky@csiro.au
+created: '2025-10-01'
 description: |-
   ACCESS-ESM1.5 global coupled model configuration running in co2 concentration driven mode under pre-industrial forcings, as described in Ziehn et al. (2020), https://doi.org/10.1071/ES19035.
   Pre-industrial forcing data including atmospheric co2 concentrations are primarily sourced from UKMO versions of CMIP6 inputs, with additional atmospheric forcings sourced from CMIP5 and land cover data adapted from Lawrence et al. (2012), https://doi.org/10.1175/JCLI-D-11-00256.1.
@@ -12,17 +12,25 @@ notes: |-
    ACCESS-NRI requests users follow the guidelines for acknowledging ACCESS-NRI and include a statement such as:
    "This research used the ACCESS-ESM1.5 model infrastructure provided by ACCESS-NRI, which is enabled by the Australian Government's National Collaborative Research Infrastructure Strategy (NCRIS)."
 keywords:
-  - global
-  - access-esm1.6
+- global
+- access-esm1.6
 realm:
-  - atmos
-  - land
-  - ocean
-  - ocnBgchem
-  - seaIce
+- atmos
+- land
+- ocean
+- ocnBgchem
+- seaIce
 nominal_resolution: 100 km
 reference: https://doi.org/10.1071/ES19035
 license: CC-BY-4.0
 model: ACCESS-ESM1.6
 version: '1.1'
-url: https://github.com/ACCESS-NRI/access-esm1.5-configs.git
+url: git@github.com:ACCESS-NRI/access-esm1.6-configs.git
+experiment_uuid: c18fc8e2-c9f2-4594-9286-e5e56e485502
+name: feat-Sept-C-test-PIspinup-Sept-B-c18fc8e2
+schema_version:  # The version of the schema (string)
+long_description: # Long description of the experiment (string)
+frequency: # The frequency(/ies) included in the experiment (string)
+variable: # The variable(s) included in the experiment (string)
+parent_experiment: # experiment_uuid for parent experiment if appropriate (string)
+related_experiments: # experiment_uuids for any related experiment(s) (string)


### PR DESCRIPTION
@ofa001 has found that 

The reason for starting earlier in the run is that  by year 600 of AprilSpinUp (where Sept-A begins), 500 after the solar constant change, the region in the Southern Ocean has already cooled down considerably and is already spilling water into the excessively cold water of deep ocean in the rest of the model (ocean timescale to reverse this is long).

This suggests we restart the model from an even earlier time. However there is a significant step change in ocean dynamics due to a revision to ocean BGC at approximately year  280(experiment counter=382). This suggests we start after this has occurred. As such the decision was made to start from restart300(experiment counter=402), 200 years earlier that Sept-A. 


Technically:
--------------
Only modifications to these two files are  relevant

```
  atmosphere/input_atm.nml - includes revised ocean albedo scaling factor (0.92)
  config.yaml                             - includes path to new restarts in config
```
  
  I didnt want to add these binaries to the repo.

  Can you please put them in vk83/ and create another branch test-PIspinup-Sept-C. 

