### PR TITLE
corresponding cable.nml change to removal of cable_runtime%esm15 in IF condition

### DIFF
--- a/atmosphere/cable.nml
+++ b/atmosphere/cable.nml
@@ -62,5 +62,6 @@
 ! filenames for CASA-CNP input files
 ! updated pftlookup file for CABLE3 format
   casafile%cnpbiome='INPUT/pftlookup_cable3_1213_exp6_c4crop.csv'  ! biome specific BGC parameters
+  cable_user%PHENOLOGY_SWITCH = 'MODIS' 
   casafile%phen='INPUT/modis_phenology_csiro_13evergreen.txt' ! phenology by latitude (modis derived)
 &end


### PR DESCRIPTION
https://github.com/ACCESS-NRI/UM7/pull/173

reqd switch to ensure same behaviour as that previously enabled by now (semi-)defunct esm15 switch. This switch has always been in this conditional, just not activated as esm15 switch was