### PR TITLE
Update README.md with link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## About
 
-This repo will contain standard global configurations for ACCESS-ESM1.6, the ACCESS Coupled Earth System Model.
+This repository will contain standard global configurations for ACCESS-ESM1.6, the ACCESS Coupled Earth System Model. See the [ACCESS-ESM1.6 configuration docs](https://access-nri.github.io/access-esm1.6-configs/) for more information on the supported configurations.
 
 This is an "omnibus repository": it contains multiple related configurations, and each
 configuration is stored in a separate branch.


### PR DESCRIPTION
Per title- add link to the config docs to the README. Given we've taken the first step at presenting this to a larger audience at the ESM1.6 standup, I think it should be easily accessible. This target is likely to change when we move to readthedocs.