### PR TITLE
Use pft file compatible with xnslope change

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -57,7 +57,7 @@ submodels:
         - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/land/soiltype/global.N96/2020.05.19/qrparm.soil_igbp_vg
         - /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/land/vegetation/global.N96/2025.08.29/cable_vegfunc_N96.anc
         - /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/land/biogeochemistry/resolution_independent/2025.08.29/modis_phenology_csiro_13evergreen.txt
-        - /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/land/biogeochemistry/resolution_independent/2025.08.29/pftlookup_cable3_1213_exp6_c4crop.csv
+        - /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/land/biogeochemistry/resolution_independent/2025.10.24/pftlookup_cable3_1213_exp6_c4crop_fxnslope.csv
         # Spectral
         - /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_sw_hadgem1_6on
         - /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_lw_hadgem1_6on

--- a/manifests/input.yaml
+++ b/manifests/input.yaml
@@ -76,11 +76,11 @@ work/atmosphere/INPUT/ozone_1850_ESM1.anc:
   hashes:
     binhash: 7e82d4a83bf18e59277f026cbbee4c74
     md5: a64a01e3b092085fca308524a75a1cee
-work/atmosphere/INPUT/pftlookup_cable3_1213_exp6_c4crop.csv:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/land/biogeochemistry/resolution_independent/2025.08.29/pftlookup_cable3_1213_exp6_c4crop.csv
+work/atmosphere/INPUT/pftlookup_cable3_1213_exp6_c4crop_fxnslope.csv:
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/land/biogeochemistry/resolution_independent/2025.10.24/pftlookup_cable3_1213_exp6_c4crop_fxnslope.csv
   hashes:
-    binhash: 28cb640d1f82c866fb2da732ee61a018
-    md5: c67bdd681339f6d9c72223f9f8aaf1b7
+    binhash: fe55792fde2aef302707ae223a7e2c36
+    md5: 8bd13eebb07cd795805ea56478f8370d
 work/atmosphere/INPUT/qrparm.mask:
   fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/grids/global.N96/2020.05.19/qrparm.mask
   hashes:


### PR DESCRIPTION
**Note:** Do not merge until the UM executable has been updated to include https://github.com/ACCESS-NRI/UM7/pull/175

Closes #251 

https://github.com/ACCESS-NRI/UM7/pull/175 removed hard wired scale parameters from the UM code. This PR updates the pft parameter file to accompany the code change. 

The new pft parameter file has been copied from `/home/599/jxs599/PAYU/Feat/feat-xnslope/pftlookup_cable3_1213_exp6_c4crop_fxnslope.csv` to `/g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/land/biogeochemistry/resolution_independent/2025.10.24/pftlookup_cable3_1213_exp6_c4crop_fxnslope.csv`

