### PR TITLE
Updated RTD build to set edit_uri dynamically

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -21,9 +21,11 @@ build:
   os: ubuntu-24.04
   tools:
     python: "3.13"
-  # jobs:
-    # post_checkout: # MODIFY IF NEEDED: uncomment to cancel the RTD build
-    #   - exit 183
+  jobs:
+    # post_checkout: ['exit 183'] # MODIFY IF NEEDED: uncomment to cancel the RTD build
+    build:
+      html:
+        - curl -sSL https://raw.githubusercontent.com/ACCESS-NRI/ACCESS-Hive-Docs/davide/test/.readthedocs/scripts/custom_build.sh | bash # Custom build
 
 # Build documentation with Mkdocs
 mkdocs:

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -9,7 +9,10 @@ site_url: !ENV READTHEDOCS_CANONICAL_URL
 # Git repository (Adds a link to the GitHub repository at the top)
 repo_url: https://github.com/ACCESS-NRI/access-esm1.6-configs
 repo_name: ACCESS-NRI/access-esm1.6-configs
-edit_uri: blob/main/documentation/docs/ #hopefully will fix the edit button from 404'ing, https://github.com/mkdocs/mkdocs/issues/2416
+
+edit_uri: !ENV [EDIT_URI, ""]
+# EDIT_URI is set within the website build (ReadTheDocs) through the ACCESS-Hive-Docs repo script
+# https://github.com/ACCESS-NRI/ACCESS-Hive-Docs/blob/main/.readthedocs/scripts/custom_build.sh
  
 # Theme
 theme:


### PR DESCRIPTION
RTD build update to set `edit_uri` dynamically.

[Successful test](https://github.com/ACCESS-NRI/access-esm1.6-configs/pull/309) for a [previously failing run](https://github.com/ACCESS-NRI/access-esm1.6-configs/actions/runs/19911489523/job/57081002898?pr=302).