### PR TITLE
Add a script to check the CO2 base year

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -157,6 +157,7 @@ sync:
 # be automatically synced at the end of a run. To sync the latest output after a postscript has completed,
 #  manually run `payu sync` from the command line.
 
-# userscripts:
+userscripts:
+    setup: scripts/check_co2_year.py
 
 postscript: -v PAYU_CURRENT_OUTPUT_DIR,PROJECT  -lstorage=${PBS_NCI_STORAGE} ./scripts/NetCDF-conversion/UM_conversion_job.sh

--- a/scripts/check_co2_year.py
+++ b/scripts/check_co2_year.py
@@ -1,0 +1,20 @@
+# Check that base year for CO2 increase is consistent with the UM restart year
+
+import os, f90nml, yaml
+
+if int(os.environ['PAYU_CURRENT_RUN']) == 0:
+    # Only check on the first run
+    nml = f90nml.read('work/atmosphere/namelists')
+    co2_year = nml['clmchfcg']['clim_fcg_years'][0][0]
+
+    with open('work/atmosphere/um.res.yaml', 'r') as calendar_file:
+        date_info = yaml.safe_load(calendar_file)
+    restart_year = date_info['end_date'].year
+    print("Restart year", restart_year)
+
+    # Want first year to have a 1% increase, so co2_year should be restart_year - 1
+    if co2_year != (restart_year - 1):
+        raise ValueError(
+            f"ERROR: clim_fcg_years in atmosphere/namelists is {co2_year}. "
+            f"For consistency with restart year use {restart_year-1}"
+        )


### PR DESCRIPTION
<!-- This template was created to cover the most complex case of new changes to the configuration. As such, all sections may not be suitable for other types of changes (e.g. documentation changes, cherry-picking changes between configurations). Please fill in all the sections you believe are suitable to your case. The reviewer(s) will ask for any missing information. Please do not delete any empty sections. -->

**1. Summary**:

Add a script to check that the base year for the 1% CO2 increase is consistent with the restart year. See https://github.com/ACCESS-NRI/access-esm1.6-configs/issues/326#issuecomment-3684641112 for some payu related issues.

**2. Issues Addressed:**
#326

**3. Dependencies (e.g. on payu, or model)**

This change requires changes to (note pull request(s) where relevant):
- [ ] workflow manager (payu):
- [ ] model deployment (ACCESS-ESM1.6):
- [ ] model component or library dependency:
- [ ] input workflow:

<!-- Describe and link to the related changes to dependencies -->

**4. Ad-hoc Testing**

Run with year set incorrectly fails with a message like
```
ValueError: ERROR: clim_fcg_years in atmosphere/namelists is 3675. For consistency with restart year use 2675
```
With correct year runs as before.

**5. CI Testing**
<!-- Has the CI-testing been run? -->
- [X] `!test repro` has been run

**6. Reproducibility**

Is this reproducible with the previous commit? (If not, why not?)
- [X] Yes
- [ ] No - `!test repro commit` has been run. <!-- add detail below for why it's answer changing -->

**7. Performance**
<!-- check the throughput of the model by running 6 months with and without your changes and recording the walltime-->

Has the model performance (say, throughput of model-years/wall-day) changed? 
- [ ] Yes
- [ ] No
- [X] N/A (if selected, please add a brief explanation why performance testing is not necessary for this PR)

Trvial startup script will not change performance.

**8. Manifests**

Have you changed the executable, the input files and/or the restart files?
- [ ] Yes
- [X] No

If yes, have you updated the manifests?
- [ ] Yes
- [ ] No

To update the manifests, run payu setup (in a cloned copy of your feature branch) with reproducibility tests turned off:

```yaml
manifest:
  reproduce:
    exe: false
    input: false
    restart: false
runlog:
  enable: false
```
Then commit the newly created manifest files (under manifests/) only to the branch for this PR.


**9. Documentation**
<!--Does this impact documentation? -->

Is the documentation updated?
- [ ] Yes
- [X] N/A

**10. Merge Strategy**
<!-- What is the planned merge strategy (Merge commit, Rebase and merge, or squash) ?
If not squash, link to the related issue in the commit descriptions -->

- [X] Merge commit
- [ ] Rebase and merge
- [ ] Squash
