### PR TITLE
Add heaviside variable for processing 6hr plev data

### DIFF
--- a/atmosphere/diagnostic_profiles/STASHC_standard_plus_dailyplev_concentrations
+++ b/atmosphere/diagnostic_profiles/STASHC_standard_plus_dailyplev_concentrations
@@ -1,5 +1,5 @@
  ### Start of user STASH requests for ATMOS ### 
- &STASHNUM NUM_REQ=292, NUM_DOM=38,  NUM_TIM=22, NUM_USE=12 /
+ &STASHNUM NUM_REQ=293, NUM_DOM=38,  NUM_TIM=22, NUM_USE=12 /
 
  # Monthly - 3D variables on model levels #
  &STREQ IMOD= 1, ISEC=0, ITEM=10, IDOM=2, ITIM=5, IUSE=2 /
@@ -310,9 +310,10 @@
  &STREQ IMOD= 1, ISEC=30, ITEM=301, IDOM=36, ITIM=1, IUSE=1 /
 
  # 6hrly - 3D variables on pressure levels #
- &STREQ IMOD= 1, ISEC=30, ITEM=201, IDOM=37, ITIM=4, IUSE=5 / #check working
+ &STREQ IMOD= 1, ISEC=30, ITEM=201, IDOM=37, ITIM=4, IUSE=5 /
  &STREQ IMOD= 1, ISEC=30, ITEM=202, IDOM=37, ITIM=4, IUSE=5 / 
  &STREQ IMOD= 1, ISEC=30, ITEM=204, IDOM=37, ITIM=4, IUSE=5 / 
+ &STREQ IMOD= 1, ISEC=30, ITEM=301, IDOM=37, ITIM=4, IUSE=5 /
 
  # 6hrly - 2D surface variables #
  &STREQ IMOD= 1, ISEC=3, ITEM=245, IDOM=1, ITIM=21, IUSE=5 / # Need to check that 6h mean works
@@ -325,7 +326,7 @@
  &STREQ IMOD= 1, ISEC=5, ITEM=216, IDOM=1, ITIM=8, IUSE=4 / 
 
  # 1hrly - 2D surface variables #
- &STREQ IMOD= 1, ISEC=5, ITEM=216, IDOM=1, ITIM=22, IUSE=7 /  # Need to check if 1h mean works
+ &STREQ IMOD= 1, ISEC=5, ITEM=216, IDOM=1, ITIM=22, IUSE=7 /
 
 
 


### PR DESCRIPTION
<!-- This template was created to cover the most complex case of new changes to the configuration. As such, all sections may not be suitable for other types of changes (e.g. documentation changes, cherry-picking changes between configurations). Please fill in all the sections you believe are suitable to your case. The reviewer(s) will ask for any missing information. Please do not delete any empty sections. -->

**1. Summary**:

What has changed?

This PR adds the heaviside variable to the 6hourly output on 3 pressure levels.

Why was this done?
The um2nc postprocessing requires heaviside variables on the same grid to accompany any pressure level variables. This is used to handle zero's that bleed into the data when pressure levels fall below ground. When the heaviside variables are missing, the postprocessing ends up dropping the pressure level variables. As a result, the 6hourly pressure level data is not currently being saved. 

This PR adds the relevant heaviside variable, allowing for the 6 hourly pressure level data to be saved.

Note: With the changes in this PR, the total yearly output (all components) increases to from ~14.5G to 15.4G

**2. Issues Addressed:**
<!-- Add links to github issue(s) this is related to -->
- #364 

**3. Dependencies (e.g. on payu, or model)**

This change requires changes to (note pull request(s) where relevant):
- [ ] workflow manager (payu):
- [ ] model deployment (ACCESS-ESM1.6):
- [ ] model component or library dependency:
- [ ] input workflow:

<!-- Describe and link to the related changes to dependencies -->

**4. Ad-hoc Testing**

What ad-hoc testing was done? How are you convinced this change is correct (plots are good)?

I compared the data in the pressure level variables before and after the processing. Since these variables are instantaneous rather than means, the heaviside masking should only mask out points which fall below the surface and not change any of the other values.

The following show the maximum absolute differences between the unprocessed and processed data from a 1 month run:

<img width="987" height="299" alt="download-43" src="https://github.com/user-attachments/assets/a8a52ff0-bfd2-47c8-bfcc-aa82dfc463da" />

<img width="975" height="299" alt="download-41" src="https://github.com/user-attachments/assets/790f993c-b8b0-40bd-8b4b-4a43add79060" />

<img width="975" height="299" alt="download-42" src="https://github.com/user-attachments/assets/fe4c94a5-e7d0-4a61-871a-4f69be67e260" />

The differences appear within rounding range. The conversion reduces to 32bit which may be the source of the differences.

I also checked that the nan points in the processed output exactly match the points which fall below the surface, according to the heaviside variable:

```
>nan_points = xr.where(np.isnan(dat_6h.fld_s30i202),1,0)
>under_surface = xr.where(dat_6h.fld_s30i301 == 0.0, 1, 0)
>print(nan_points.equals(under_surface))

True
```

**5. CI Testing**
<!-- Has the CI-testing been run? -->
- [x] `!test repro` has been run

**6. Reproducibility**

Is this reproducible with the previous commit? (If not, why not?)
- [x] Yes
- [ ] No - `!test repro commit` has been run. <!-- add detail below for why it's answer changing -->

**7. Performance**
<!-- check the throughput of the model by running 6 months with and without your changes and recording the walltime-->

Has the model performance (say, throughput of model-years/wall-day) changed? 
- [ ] Yes
- [x] No
- [ ] N/A (if selected, please add a brief explanation why performance testing is not necessary for this PR)

00:57:44 Minute runtime for 1 year, I think within current range?

If yes, provide the numbers from your testing. Is the performance better or worse?

**8. Manifests**

Have you changed the executable, the input files and/or the restart files?
- [ ] Yes
- [x] No

If yes, have you updated the manifests?
- [ ] Yes
- [ ] No

To update the manifests, run payu setup (in a cloned copy of your feature branch) with reproducibility tests turned off:

```yaml
manifest:
  reproduce:
    exe: false
    input: false
    restart: false
runlog:
  enable: false
```
Then commit the newly created manifest files (under manifests/) only to the branch for this PR.


**9. Documentation**
<!--Does this impact documentation? -->

Is the documentation updated?
- [ ] Yes
- [x] N/A

**10. Merge Strategy**
<!-- What is the planned merge strategy (Merge commit, Rebase and merge, or squash) ?
If not squash, link to the related issue in the commit descriptions -->

- [ ] Merge commit
- [ ] Rebase and merge
- [x] Squash
