### PR TITLE
Use STASHmaster_A with corrected LBVC for model level cloud fields. (…

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -69,7 +69,7 @@ submodels:
           # - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/grids/global.N96/2020.05.19/qrparm.mask
           # - /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/grids/resolution_independent/2020.05.19/vertlevs_G3
         # STASH
-        - /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2025.12.19/
+        - /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2026.01.21/
         # Boundary conditions
         - /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/amip/atmosphere/boundary_conditions/global.N96/2021.07.08/amip_seaice_n96_greg.pp
         - /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/amip/atmosphere/boundary_conditions/global.N96/2021.07.08/amip_sst_n96_greg.pp

--- a/manifests/input.yaml
+++ b/manifests/input.yaml
@@ -37,34 +37,34 @@ work/atmosphere/INPUT/OCFF_1849_2023_cmip7.anc:
     binhash: 87e11cdf24eccfb2166e849a818ca909
     md5: 0be90f4ac9c50ad3c5b70388cd4f9fd6
 work/atmosphere/INPUT/STASHmaster/README:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2025.12.19/STASHmaster/README
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2026.01.21/STASHmaster/README
   hashes:
-    binhash: 01e4a19f6616aaa0aeb3a41965a6be9d
-    md5: 4b9b721b80b3a2e1d292cdab756f14a5
+    binhash: dd48aaec06d8a65d764c0595b6748f03
+    md5: 68d47be694979b827a9f68088d8d5800
 work/atmosphere/INPUT/STASHmaster/STASHmaster_A:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2025.12.19/STASHmaster/STASHmaster_A
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2026.01.21/STASHmaster/STASHmaster_A
   hashes:
-    binhash: c4f0b8856159cca024b69f03443d1176
-    md5: d257ddb7a98b882c3ac492f408df7793
+    binhash: 69257dc3199aee9b47c48ad2a532cd9e
+    md5: 808dac1f259bf3e3fb468462ccbbee81
 work/atmosphere/INPUT/STASHmaster/STASHmaster_O:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2025.12.19/STASHmaster/STASHmaster_O
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2026.01.21/STASHmaster/STASHmaster_O
   hashes:
-    binhash: 1a82f824556c2da2f712ec1271fde2cf
+    binhash: 76c188f1b29929a1a4cfc66a2a1bde93
     md5: 5a65d77c62d55e3b62e35ad9662d32a9
 work/atmosphere/INPUT/STASHmaster/STASHmaster_S:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2025.12.19/STASHmaster/STASHmaster_S
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2026.01.21/STASHmaster/STASHmaster_S
   hashes:
-    binhash: dd55b55f5cce7bd9442bb6d194a85c93
+    binhash: e10f471a240cbb6ab47d9941850ae31a
     md5: 85ff5d563968cf24d1be595b05b4e52d
 work/atmosphere/INPUT/STASHmaster/STASHmaster_W:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2025.12.19/STASHmaster/STASHmaster_W
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2026.01.21/STASHmaster/STASHmaster_W
   hashes:
-    binhash: 7be6a163341f49473d8179f183609a4e
+    binhash: c131e6e7d9b00472b083b4290644341e
     md5: 1e4391ea1f6234b33c33168bd7089d06
 work/atmosphere/INPUT/STASHmaster/STASHsections_A:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2025.12.19/STASHmaster/STASHsections_A
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2026.01.21/STASHmaster/STASHsections_A
   hashes:
-    binhash: afb52507011158a9ae30fb368d06f2c2
+    binhash: 2af3017149d587a0ba600d22024f7c0f
     md5: 8525fd107dbea6184db74089f1d55fd9
 work/atmosphere/INPUT/TSI_CMIP7_ESM:
   fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/historical/atmosphere/forcing/resolution_independent/2025.11.25/TSI_CMIP7_ESM
@@ -122,104 +122,104 @@ work/atmosphere/INPUT/spec3a_sw_hadgem1_6on:
     binhash: 149899ecc54ed754ab8c6f05cb99f140
     md5: 0e74c13cf3333132f38d8c5c52e1c7eb
 work/atmosphere/INPUT/stasets/X01001218:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2025.12.19/stasets/X01001218
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2026.01.21/stasets/X01001218
   hashes:
-    binhash: 4a2fcf832b7f8a1af9be58a81cae5ce3
+    binhash: e5c100e78082bd07ea0d5d299a973356
     md5: 7293caa27798d235bd5520eede9700fb
 work/atmosphere/INPUT/stasets/X01002207:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2025.12.19/stasets/X01002207
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2026.01.21/stasets/X01002207
   hashes:
-    binhash: 33a0eba5237db140fa882a18a40c7857
+    binhash: 50a73eef1f79b1449325dbf7e40cb579
     md5: 448daeebba685950d0c347d0493b5fc4
 work/atmosphere/INPUT/stasets/X01003236:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2025.12.19/stasets/X01003236
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2026.01.21/stasets/X01003236
   hashes:
-    binhash: aafd86926894f4594c6062a495c0fa0e
+    binhash: 5630ac65d4e2a72e68fd693559d60f72
     md5: 71a2288ee0a7d0fc89dafe95653c128a
 work/atmosphere/INPUT/stasets/X01003237:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2025.12.19/stasets/X01003237
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2026.01.21/stasets/X01003237
   hashes:
-    binhash: 1bb68e38a6084c8a2767bd6893603d3e
+    binhash: 61c20338fd23e02926d12cb21b1ad17d
     md5: 4efd39ac9a917525bbc35146d6770e3b
 work/atmosphere/INPUT/stasets/X01003254:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2025.12.19/stasets/X01003254
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2026.01.21/stasets/X01003254
   hashes:
-    binhash: 207f67096815d4664ac7982648b8d8f1
+    binhash: 8a1daadc09eae1018a72273320e7b576
     md5: 1b5f7755f752c2ee2086ac6eba886ca3
 work/atmosphere/INPUT/stasets/X01003255:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2025.12.19/stasets/X01003255
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2026.01.21/stasets/X01003255
   hashes:
-    binhash: 3cea8088b0d54e4597c0741441787cfb
+    binhash: 05f279a0fede7a9d5f9cab5b34678567
     md5: f23a78b048f0cb52ed0e2beb57f00fa8
 work/atmosphere/INPUT/stasets/X01003274:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2025.12.19/stasets/X01003274
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2026.01.21/stasets/X01003274
   hashes:
-    binhash: f856ed8d2d0ff403ffa9e94dfe0c8fb2
+    binhash: e21b1e2f8504cdfc2a366becdf0c143d
     md5: 032190f23c926eb47199da6e1f054bf1
 work/atmosphere/INPUT/stasets/X01003275:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2025.12.19/stasets/X01003275
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2026.01.21/stasets/X01003275
   hashes:
-    binhash: 29ac8a8f7e754036d1abbfc9029b4a32
+    binhash: 6f0991ba269c7fd2eef285c844a5eae6
     md5: 120694f3d078b9ade033b56217e9ed85
 work/atmosphere/INPUT/stasets/X01003276:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2025.12.19/stasets/X01003276
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2026.01.21/stasets/X01003276
   hashes:
-    binhash: 43c3ac834df0358c81f6221396068c95
+    binhash: ed36f30479fd39213deb3e5c32fae431
     md5: 61afb6eb4e76efb2171c56d02742e9ad
 work/atmosphere/INPUT/stasets/X01003277:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2025.12.19/stasets/X01003277
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2026.01.21/stasets/X01003277
   hashes:
-    binhash: 6238e630892522b0f46acd3e1d44fda0
+    binhash: 447fd0016956c4ab1920d68426acd77a
     md5: d8cced93214dd8e84c0c9d06259412ab
 work/atmosphere/INPUT/stasets/X01003278:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2025.12.19/stasets/X01003278
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2026.01.21/stasets/X01003278
   hashes:
-    binhash: e935ca61d8b752d7d093c64acca24e97
+    binhash: 46d73862b86b80866a94e3d6bbcabc83
     md5: 032190f23c926eb47199da6e1f054bf1
 work/atmosphere/INPUT/stasets/X01003279:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2025.12.19/stasets/X01003279
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2026.01.21/stasets/X01003279
   hashes:
-    binhash: 6af3413a4e20a6c7886c9da83b29a406
+    binhash: f5f44da1995cbb07755dbc3012f066e2
     md5: 120694f3d078b9ade033b56217e9ed85
 work/atmosphere/INPUT/stasets/X01003280:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2025.12.19/stasets/X01003280
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2026.01.21/stasets/X01003280
   hashes:
-    binhash: 99f55e386151a5dd2a088896fc4a6ca0
+    binhash: b9f346dae64f793b24844f4ff5f90a12
     md5: 61afb6eb4e76efb2171c56d02742e9ad
 work/atmosphere/INPUT/stasets/X01003281:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2025.12.19/stasets/X01003281
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2026.01.21/stasets/X01003281
   hashes:
-    binhash: c79daa736f08def365936f862885cde0
+    binhash: 2216fb97ea72cb8056b985732853d3e4
     md5: d8cced93214dd8e84c0c9d06259412ab
 work/atmosphere/INPUT/stasets/X01003286:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2025.12.19/stasets/X01003286
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2026.01.21/stasets/X01003286
   hashes:
-    binhash: f9521fa75f35a1560427898f8af88337
+    binhash: 58e976a5d2780b10f92d0d925363da0b
     md5: 062ab130605e4771a89b2a300a6154bf
 work/atmosphere/INPUT/stasets/X01005207:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2025.12.19/stasets/X01005207
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2026.01.21/stasets/X01005207
   hashes:
-    binhash: 6b6a12743ac6963e668640cb9e98f0e5
+    binhash: 936fa5a2a4185914412b4d3377805854
     md5: 3d1ccb47257c379b909e8d6098ab95a0
 work/atmosphere/INPUT/stasets/X01005208:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2025.12.19/stasets/X01005208
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2026.01.21/stasets/X01005208
   hashes:
-    binhash: defb4bb479a4d78f81652f3413ad03ee
+    binhash: 894598be8f19e566e523022875949962
     md5: 8685052394200b839f115a667e7890ff
 work/atmosphere/INPUT/stasets/X01005222:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2025.12.19/stasets/X01005222
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2026.01.21/stasets/X01005222
   hashes:
-    binhash: ad2c3364e969423021abe903e5d82aae
+    binhash: 87367a6d692826d2343926c4a4e688c5
     md5: 3edd8e46166dbed4102c329991a7a497
 work/atmosphere/INPUT/stasets/X01005223:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2025.12.19/stasets/X01005223
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2026.01.21/stasets/X01005223
   hashes:
-    binhash: e4785752007a33ac800835988d38a2e6
+    binhash: 2a6d7ff04dcf89c2241ae1df46129db4
     md5: 4633fea316272fd71cd823881d100c14
 work/atmosphere/INPUT/stasets/X01010206:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2025.12.19/stasets/X01010206
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/stash/2026.01.21/stasets/X01010206
   hashes:
-    binhash: 2a115dffeeb330f2809743d264fd2455
+    binhash: 96a108bea8d960fa65987115a58621eb
     md5: 7d5e82e70a2f3936743eb957462d41aa
 work/atmosphere/INPUT/sulpc_oxidants_N96_L38:
   fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/sulpc_oxidants_N96_L38


### PR DESCRIPTION
As for #391

Automatic merge to dev-amip failed because the change inadvertently included removing a space at the end of the line setting the ocean exe.