### PR TITLE
Use pftlookup file with phosphorous leaching fix

### DIFF
--- a/atmosphere/cable.nml
+++ b/atmosphere/cable.nml
@@ -55,7 +55,7 @@
   l_vcmaxFeedbk = .TRUE.  ! using prognostic Vcmax
 ! filenames for CASA-CNP input files
 ! updated pftlookup file for CABLE3 format
-  casafile%cnpbiome='INPUT/pftlookup_cable3_OctB_test.csv'  ! biome specific BGC parameters
+  casafile%cnpbiome='INPUT/pftlookup_cable3_Pfix.csv'  ! biome specific BGC parameters
   cable_user%PHENOLOGY_SWITCH = 'MODIS' 
   casafile%phen='INPUT/modis_phenology_csiro_13evergreen.txt' ! phenology by latitude (modis derived)
 &end

--- a/atmosphere/cable.nml
+++ b/atmosphere/cable.nml
@@ -55,7 +55,7 @@
   l_vcmaxFeedbk = .TRUE.  ! using prognostic Vcmax
 ! filenames for CASA-CNP input files
 ! updated pftlookup file for CABLE3 format
-  casafile%cnpbiome='INPUT/pftlookup_cable3_OctB_update.csv'  ! biome specific BGC parameters
+  casafile%cnpbiome='INPUT/pftlookup_cable3_OctB_test.csv'  ! biome specific BGC parameters
   cable_user%PHENOLOGY_SWITCH = 'MODIS' 
   casafile%phen='INPUT/modis_phenology_csiro_13evergreen.txt' ! phenology by latitude (modis derived)
 &end

--- a/config.yaml
+++ b/config.yaml
@@ -56,7 +56,7 @@ submodels:
         - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/land/soiltype/global.N96/2020.05.19/qrparm.soil_igbp_vg
         - /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/land/vegetation/global.N96/2025.08.29/cable_vegfunc_N96.anc
         - /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/land/biogeochemistry/resolution_independent/2025.08.29/modis_phenology_csiro_13evergreen.txt
-        - /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/land/biogeochemistry/resolution_independent/2026.02.10/pftlookup_cable3_OctB_test.csv
+        - /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/land/biogeochemistry/resolution_independent/2026.02.10/pftlookup_cable3_Pfix.csv
         # Spectral
         - /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_sw_hadgem1_6on
         - /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_lw_hadgem1_6on

--- a/config.yaml
+++ b/config.yaml
@@ -56,7 +56,7 @@ submodels:
         - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/land/soiltype/global.N96/2020.05.19/qrparm.soil_igbp_vg
         - /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/land/vegetation/global.N96/2025.08.29/cable_vegfunc_N96.anc
         - /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/land/biogeochemistry/resolution_independent/2025.08.29/modis_phenology_csiro_13evergreen.txt
-        - /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/land/biogeochemistry/resolution_independent/2025.11.18/pftlookup_cable3_OctB_update.csv
+        - /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/land/biogeochemistry/resolution_independent/2026.02.10/pftlookup_cable3_OctB_test.csv
         # Spectral
         - /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_sw_hadgem1_6on
         - /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_lw_hadgem1_6on

--- a/manifests/input.yaml
+++ b/manifests/input.yaml
@@ -76,10 +76,10 @@ work/atmosphere/INPUT/ozone_1850_cmip7.anc:
   hashes:
     binhash: 2a41154776891cf69225b8c98c387761
     md5: 1e32029cfa87e950b9ce6e4dd1211c6e
-work/atmosphere/INPUT/pftlookup_cable3_OctB_test.csv:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/land/biogeochemistry/resolution_independent/2026.02.10/pftlookup_cable3_OctB_test.csv
+work/atmosphere/INPUT/pftlookup_cable3_Pfix.csv:
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/land/biogeochemistry/resolution_independent/2026.02.10/pftlookup_cable3_Pfix.csv
   hashes:
-    binhash: 64a5e3a9daa9c381490c764de721464e
+    binhash: a8d18513f014fe1fb4d57f36f9a53321
     md5: d9a4d71ee8038029739c23a1b829ab6a
 work/atmosphere/INPUT/qrparm.mask:
   fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/grids/global.N96/2020.05.19/qrparm.mask

--- a/manifests/input.yaml
+++ b/manifests/input.yaml
@@ -76,11 +76,11 @@ work/atmosphere/INPUT/ozone_1850_cmip7.anc:
   hashes:
     binhash: 2a41154776891cf69225b8c98c387761
     md5: 1e32029cfa87e950b9ce6e4dd1211c6e
-work/atmosphere/INPUT/pftlookup_cable3_OctB_update.csv:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/land/biogeochemistry/resolution_independent/2025.11.18/pftlookup_cable3_OctB_update.csv
+work/atmosphere/INPUT/pftlookup_cable3_OctB_test.csv:
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/land/biogeochemistry/resolution_independent/2026.02.10/pftlookup_cable3_OctB_test.csv
   hashes:
-    binhash: 9c4c143d53559b2ac70ea8eb37af48c2
-    md5: bf80c75ce38f147dd46323323d3039e2
+    binhash: 64a5e3a9daa9c381490c764de721464e
+    md5: d9a4d71ee8038029739c23a1b829ab6a
 work/atmosphere/INPUT/qrparm.mask:
   fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/grids/global.N96/2020.05.19/qrparm.mask
   hashes:


### PR DESCRIPTION
<!-- This template was created to cover the most complex case of new changes to the configuration. As such, all sections may not be suitable for other types of changes (e.g. documentation changes, cherry-picking changes between configurations). Please fill in all the sections you believe are suitable to your case. The reviewer(s) will ask for any missing information. Please do not delete any empty sections. -->

**1. Summary**:

What has changed?

This PR swaps to the pftlookup file containing the fix for the phosphorous leaching bug. The diff between the old and new versions of the file are shown below:

```diff
soilorder, gP/m2   , gP/m2     , no dimen, mic, slow, pass, xkplab     , xkpsorb      , xkpocc     ,  ,  ,,,,,,,,,
- 1        , 74.5408 , 745.40795 , 0.0005  , 4  ,  5  ,  5  , 0.001369863, 1.8356191E-05, 2.73973E-05, 5, 5,,,,,,,,,
- 2        , 68.1584 , 788.0815  , 0.0005  , 4  ,  5  ,  5  , 0.001369863, 2.0547975E-05, 2.73973E-05, 5, 5,,,,,,,,,
- 3        , 77.952  , 1110.81605, 0.0005  , 4  ,  5  ,    5  , 0.001369863, 1.3698650E-05, 2.73973E-05, 5, 5,,,,,,,,,
- 4        , 64.41918, 744.84695 , 0.0005  , 4  , 15  , 15  , 0.001369863, 1.4794542E-05, 2.73973E-05, 5, 5,,,,,,,,,
- 5        , 64.41918, 744.84695 , 0.0005  , 4  ,  5  ,  5  , 0.001369863, 2.1369894E-05, 2.73973E-05, 5, 5,,,,,,,,,
- 6        , 70.5856 , 816.14595 , 0.0005  , 4  ,  5  ,  5  , 0.001369863, 2.3835651E-05, 2.73973E-05, 5, 5,,,,,,,,,
- 7        , 64.5888 , 746.8081  , 0.0005  , 4  ,  5  ,  5  , 0.001369863, 1.9452083E-05, 2.73973E-05, 5, 5,,,,,,,,,
- 8        , 54.1692 , 722.25595 , 0.0005  , 4  ,  5  ,  5  , 0.001369863, 2.1095921E-05, 2.73973E-05, 5, 5,,,,,,,,,
- 9        , 9.7704  , 293.112   , 0.0005  , 4  ,  7  ,  7  , 0.001369863, 2.7123327E-05, 2.73973E-05, 7, 7,,,,,,,,,
- 10       , 28.29   , 311.19    , 0.0005  , 4  ,  7  ,  7  , 0.001369863, 2.1095921E-05, 2.73973E-05, 7, 7,,,,,,,,,
- 11       , 63.963  , 373.1175  , 0.0005  , 4  ,  7  ,  7  , 0.001369863, 2.7123327E-05, 2.73973E-05, 7, 7,,,,,,,,,
- 12       , 32.402  , 615.63805 , 0.0005  , 4  ,  7  ,  7  , 0.001369863, 2.1095921E-05, 2.73973E-05, 7, 7,,,,,,,,,
---
+ 1        , 74.5408 , 745.40795 , 0.0001  , 4  ,  5  ,  5  , 0.001369863, 1.8356191E-05, 2.73973E-05, 5, 5,,,,,,,,,
+ 2        , 68.1584 , 788.0815  , 0.0001  , 4  ,  5  ,  5  , 0.001369863, 2.0547975E-05, 2.73973E-05, 5, 5,,,,,,,,,
+ 3        , 77.952  , 1110.81605, 0.0001  , 4  ,  5  ,    5  , 0.001369863, 1.3698650E-05, 2.73973E-05, 5, 5,,,,,,,,,
+ 4        , 64.41918, 744.84695 , 0.0001  , 4  , 15  , 15  , 0.001369863, 1.4794542E-05, 2.73973E-05, 5, 5,,,,,,,,,
+ 5        , 64.41918, 744.84695 , 0.0001  , 4  ,  5  ,  5  , 0.001369863, 2.1369894E-05, 2.73973E-05, 5, 5,,,,,,,,,
+ 6        , 70.5856 , 816.14595 , 0.0001  , 4  ,  5  ,  5  , 0.001369863, 2.3835651E-05, 2.73973E-05, 5, 5,,,,,,,,,
+ 7        , 64.5888 , 746.8081  , 0.0001  , 4  ,  5  ,  5  , 0.001369863, 1.9452083E-05, 2.73973E-05, 5, 5,,,,,,,,,
+ 8        , 54.1692 , 722.25595 , 0.0001  , 4  ,  5  ,  5  , 0.001369863, 2.1095921E-05, 2.73973E-05, 5, 5,,,,,,,,,
+ 9        , 9.7704  , 293.112   , 0.0001  , 4  ,  7  ,  7  , 0.001369863, 2.7123327E-05, 2.73973E-05, 7, 7,,,,,,,,,
+ 10       , 28.29   , 311.19    , 0.0001  , 4  ,  7  ,  7  , 0.001369863, 2.1095921E-05, 2.73973E-05, 7, 7,,,,,,,,,
+ 11       , 63.963  , 373.1175  , 0.0001  , 4  ,  7  ,  7  , 0.001369863, 2.7123327E-05, 2.73973E-05, 7, 7,,,,,,,,,
+ 12       , 32.402  , 615.63805 , 0.0001  , 4  ,  7  ,  7  , 0.001369863, 2.1095921E-05, 2.73973E-05, 7, 7,,,,,,,,,
```

Why was this done?

This change is necessary to fix the issues with the depleting phosphorous pools identified [here](https://forum.access-hive.org.au/t/csiro-access-nri-standup-minutes/3789/73)

**2. Issues Addressed:**
<!-- Add links to github issue(s) this is related to -->
- #439 

**3. Dependencies (e.g. on payu, or model)**

This change requires changes to (note pull request(s) where relevant):
- [ ] workflow manager (payu):
- [ ] model deployment (ACCESS-ESM1.6):
- [ ] model component or library dependency:
- [ ] input workflow:

<!-- Describe and link to the related changes to dependencies -->

**4. Ad-hoc Testing**

What ad-hoc testing was done? How are you convinced this change is correct (plots are good)?

**5. CI Testing**
<!-- Has the CI-testing been run? -->
- [x] `!test repro` has been run

**6. Reproducibility**

Is this reproducible with the previous commit? (If not, why not?)
- [ ] Yes
- [ ] No - `!test repro commit` has been run. <!-- add detail below for why it's answer changing -->

**7. Performance**
<!-- check the throughput of the model by running 6 months with and without your changes and recording the walltime-->

Has the model performance (say, throughput of model-years/wall-day) changed? 
- [ ] Yes
- [ ] No
- [x] N/A (if selected, please add a brief explanation why performance testing is not necessary for this PR)

Change to cable parameter not expected to impact performance

If yes, provide the numbers from your testing. Is the performance better or worse?

**8. Manifests**

Have you changed the executable, the input files and/or the restart files?
- [x] Yes
- [ ] No

If yes, have you updated the manifests?
- [x] Yes
- [ ] No

To update the manifests, run payu setup (in a cloned copy of your feature branch) with reproducibility tests turned off:

```yaml
manifest:
  reproduce:
    exe: false
    input: false
    restart: false
runlog:
  enable: false
```
Then commit the newly created manifest files (under manifests/) only to the branch for this PR.


**9. Documentation**
<!--Does this impact documentation? -->

Is the documentation updated?
- [ ] Yes
- [x] N/A

**10. Merge Strategy**
<!-- What is the planned merge strategy (Merge commit, Rebase and merge, or squash) ?
If not squash, link to the related issue in the commit descriptions -->

- [ ] Merge commit
- [ ] Rebase and merge
- [x] Squash
