### PR TITLE
Enable MOM cf_compliance flag

### DIFF
--- a/ocean/input.nml
+++ b/ocean/input.nml
@@ -218,6 +218,7 @@
 &mpp_io_nml
     deflate_level     = 4
     shuffle           = 1
+    cf_compliance=.true.
 /
 
  &ocean_momentum_source_nml


### PR DESCRIPTION
<!-- This template was created to cover the most complex case of new changes to the configuration. As such, all sections may not be suitable for other types of changes (e.g. documentation changes, cherry-picking changes between configurations). Please fill in all the sections you believe are suitable to your case. The reviewer(s) will ask for any missing information. Please do not delete any empty sections. -->

**1. Summary**:

This PR enables the `cf_compliace` flag in the MOM `input.nml` namelist. This modifies the attributes in the MOM netCDF output files for CF compliance, including changes such as unifying the `time` and `time_bnds` units attributes, and removing `none` units. See #502  for a full list of the attribute changes.

These changes will simplify the CMORisation, and also fix a long standing issue with loading model output in xarray due to the `time_bnds` attribute missmatch.

**2. Issues Addressed:**
<!-- Add links to github issue(s) this is related to -->
- #502 

**3. Dependencies (e.g. on payu, or model)**

This change requires changes to (note pull request(s) where relevant):
- [ ] workflow manager (payu):
- [ ] model deployment (ACCESS-ESM1.6):
- [ ] model component or library dependency:
- [ ] input workflow:

<!-- Describe and link to the related changes to dependencies -->

**4. Ad-hoc Testing**

The following is from an ncdump of a model output file with `cf_compliance=.true.`
```
	double time_bnds(time, nv) ;
		time_bnds:long_name = "time axis boundaries" ;
		time_bnds:units = "days since 0001-01-01 00:00:00" ;
		time_bnds:missing_value = 1.e+20 ;
		time_bnds:_FillValue = 1.e+20 ;
```
Compared to a run with `cf_compliance=.false.`, the actual output data is identical:
<img width="425" height="314" alt="download-79" src="https://github.com/user-attachments/assets/100958d6-66ee-40e1-825b-59f279784fd0" />


Loading in the data with `xr.load_dataset(...)` works without any issues with this change. With `cf_compliance=.false.` we get the error:
```
OutOfBoundsTimedelta: Cannot convert 84414787200 seconds to timedelta64[ns] without overflow
```

**5. CI Testing**
<!-- Has the CI-testing been run? -->
- [x] `!test repro` has been run

**6. Reproducibility**

Is this reproducible with the previous commit? (If not, why not?)
- [ ] Yes
- [ ] No - `!test repro commit` has been run. <!-- add detail below for why it's answer changing -->

**7. Performance**
<!-- check the throughput of the model by running 6 months with and without your changes and recording the walltime-->

Has the model performance (say, throughput of model-years/wall-day) changed? 
- [ ] Yes
- [ ] No
- [ ] N/A (if selected, please add a brief explanation why performance testing is not necessary for this PR)

This PR makes small changes to the netCDF attributes when MOM writes output, which isn't expected to affect 
If yes, provide the numbers from your testing. Is the performance better or worse?

**8. Manifests**

Have you changed the executable, the input files and/or the restart files?
- [ ] Yes
- [x] No

If yes, have you updated the manifests?
- [ ] Yes
- [ ] No

To update the manifests, run payu setup (in a cloned copy of your feature branch) with reproducibility tests turned off:

```yaml
manifest:
  reproduce:
    exe: false
    input: false
    restart: false
runlog:
  enable: false
```
Then commit the newly created manifest files (under manifests/) only to the branch for this PR.


**9. Documentation**
<!--Does this impact documentation? -->

Is the documentation updated?
- [ ] Yes
- [x] N/A

**10. Merge Strategy**
<!-- What is the planned merge strategy (Merge commit, Rebase and merge, or squash) ?
If not squash, link to the related issue in the commit descriptions -->

- [ ] Merge commit
- [ ] Rebase and merge
- [x] Squash
