### PR TITLE
Use release versions for CI on `release-` branches

### DIFF
--- a/config/ci.json
+++ b/config/ci.json
@@ -26,6 +26,10 @@
     "qa": {
         "default": {
             "markers": "access_esm1p6 or config"
+        },
+         "release-.*": {
+            "model-config-tests-version": "0.2.3",
+            "payu-version": "1.3.0"
         }
     },
     "default": {

--- a/config/ci.json
+++ b/config/ci.json
@@ -17,6 +17,10 @@
     "reproducibility": {
         "default": {
             "markers": "repro and (not repro_restart)"
+        },
+        "release-.*": {
+            "model-config-tests-version": "0.2.3",
+            "payu-version": "1.3.0"
         }
     },
     "qa": {


### PR DESCRIPTION
Contributes to #746 

use release versions of payu and model-config-tests for `release-` branhces