### PR TITLE
Use model release for suggested reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains standard global configurations for ACCESS-ESM1.6, the A
 The developers of ACCESS-ESM1.6 request that users of these model configurations
 
 1. Have a Met Office Science Repository Service (MOSRS) account as described on [ACCESS-Hive Docs](https://docs.access-hive.org.au/models/run_a_model/run_access-esm/#prerequisites).
-1. Cite https://doi.org/10.1071/ES19035A model description paper. A new paper for ACCESS-ESM1.6 is in preparation.
+1. Currently please cite https://doi.org/10.5281/zenodo.17490072. A model description paper for ACCESS-ESM1.6 is in preparation.
 1. Follow the [guidelines for acknowledging ACCESS-NRI](https://www.access-nri.org.au/resources/acknowledging-us/) and also acknowledge the ongoing science developments led by CSIRO, by including a statement such as:
 _This research used the ACCESS-ESM1.6 model infrastructure provided by ACCESS-NRI, which is enabled by the Australian Government’s National Collaborative Research Infrastructure Strategy (NCRIS). Science development of ACCESS-ESM1.6 was led by CSIRO with support from the Australian Government's National Environmental Science Program Climate Systems Hub._
 


### PR DESCRIPTION
Following the discussion [here](https://github.com/ACCESS-NRI/access-esm1.6-configs/pull/766#discussion_r3284938942), this PR updates the main branch README to use the zenodo reference to the model release. We can use this for the time being, while there isn't yet a model description paper. 

I'll wait to for #766 to be approved, so that any wording changes there are matched here.