### PR TITLE
Update metadata.yaml for ESM1.6

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,15 +2,13 @@ contact: Add your name here
 email: Add your email address here
 created: Add the date you started the experiment here (YYYY-MM-DD)
 description: |-
-  ACCESS-ESM1.5 global coupled model configuration running in co2 concentration driven mode under historical forcings, as described in Ziehn et al. (2020), https://doi.org/10.1071/ES19035.
-  Pre-industrial forcing data including atmospheric co2 concentrations are primarily sourced from UKMO versions of CMIP6 inputs, with additional atmospheric forcings sourced from CMIP5 and land cover data adapted from Lawrence et al. (2012), https://doi.org/10.1175/JCLI-D-11-00256.1.
+  ACCESS-ESM1.6 global coupled model configuration running in co2 concentration driven mode under historical forcings. Historical forcing data including atmospheric co2 concentrations are primarily sourced from the input4MIPs CMIP7 datasets.
 notes: |-
   The developers of ACCESS-ESM1.6 request that users of these model configurations:
-   (a) Cite https://doi.org/10.1071/ES19035
-   (b) Include an acknowledgment such as the following:
-   "The authors thank CSIRO for developing the ACCESS-ESM1.6 model configuration and making it freely available to researchers."
-   ACCESS-NRI requests users follow the guidelines for acknowledging ACCESS-NRI and include a statement such as:
-   "This research used the ACCESS-ESM1.6 model infrastructure provided by ACCESS-NRI, which is enabled by the Australian Government's National Collaborative Research Infrastructure Strategy (NCRIS)."
+    (1) Have a Met Office Science Repository Service (MOSRS) account as described on ACCESS-Hive Docs (https://docs.access-hive.org.au/models/run_a_model/run_access-esm/#prerequisites).
+    (2) Currently please cite https://doi.org/10.5281/zenodo.17490072. A model description paper for ACCESS-ESM1.6 is in preparation.
+    (3) Follow the guidelines for acknowledging ACCESS-NRI (https://www.access-nri.org.au/resources/acknowledging-us/) and also acknowledge the ongoing science developments led by CSIRO, by including a statement such as:
+        "This research used the ACCESS-ESM1.6 model infrastructure provided by ACCESS-NRI, which is enabled by the Australian Government’s National Collaborative Research Infrastructure Strategy (NCRIS). Science development of ACCESS-ESM1.6 was led by CSIRO with support from the Australian Government's National Environmental Science Program Climate Systems Hub."
 keywords:
   - global
   - access-esm1.6
@@ -21,8 +19,8 @@ realm:
   - ocnBgchem
   - seaIce
 nominal_resolution: 100 km
-reference: https://doi.org/10.1071/ES19035
+reference: https://doi.org/10.5281/zenodo.17490072
 license: CC-BY-4.0
 model: ACCESS-ESM1.6
 version: '1.0'
-url: https://github.com/ACCESS-NRI/access-esm1.5-configs.git
+url: https://github.com/ACCESS-NRI/access-esm1.6-configs.git


### PR DESCRIPTION
This PR addresses #735 for the historical configuration. It copies the updated metadata.yaml file from the dev-piControl branch, and updates the description to be accurate to the historical configuration.

See [here](https://github.com/ACCESS-NRI/access-esm1.6-configs/compare/dev-piControl..735-historical-metadata#diff-d186204ea7abb85bbadd9d94ab29d5bcefcc43d6a0ed06015e98a71b2f099423) for a comparison with the metadata.yaml file from the dev-piControl configuration.