### PR TITLE
Add guidelines for running CMIP7 experiments

### DIFF
--- a/documentation/docs/pages/configs_experiments/fast_track_guidelines.md
+++ b/documentation/docs/pages/configs_experiments/fast_track_guidelines.md
@@ -49,7 +49,7 @@ payu clone git@github.com:ACCESS-Community-Hub/access-esm1.6-dev-experiments.git
 !!! warning
     If you are cloning an experiment which has been set up for you on the [access-esm1.6-dev-experiments](https://github.com/ACCESS-Community-Hub/access-esm1.6-dev-experiments) GitHub repository, it's important that you don't change the local branch name using the `-b <local-branch-name>` option from the `payu clone` command.*
 
-Once the experiment has been cloned, you can navigate to the control directroy and run it using the usual `payu run -n <n runs>` command.
+Once the experiment has been cloned, you can `cd` into the control directory cloned in the command above and run it using the usual `payu run -n <n runs>` command.
 
 !!! tip
     Some experiments will require a more complicated setup, such as scripts that need to be run before the initial simulation. Other experiments may need to be cloned from the [configuration repository](https://github.com/ACCESS-NRI/access-esm1.6-configs) rather than the [experiments repository](https://github.com/ACCESS-Community-Hub/access-esm1.6-dev-experiments). In these cases, ACCESS-NRI staff will provide you with specific instructions.

--- a/documentation/docs/pages/configs_experiments/fast_track_guidelines.md
+++ b/documentation/docs/pages/configs_experiments/fast_track_guidelines.md
@@ -79,17 +79,11 @@ Output and restart files for ESM1.6 fast track experiments are being archived to
 
 
 ## Pushing completed experiments back to the repository
-Once your simulations are complete, you'll need to push the runlogs back up to the [access-esm1.6-dev-experiments](https://github.com/ACCESS-Community-Hub/access-esm1.6-dev-experiments) GitHub repository using the following steps:
+Once your simulations are complete, you'll need to push the runlogs back up to the [access-esm1.6-dev-experiments](https://github.com/ACCESS-Community-Hub/access-esm1.6-dev-experiments) GitHub repository using the following step:
 
-1.  First find the local branch name for each experiment by running the following command in the control directory:
-    ```bash
-    $ payu branch
-    * Current Branch: <experiment-branch-name>
-        experiment_uuid: 3e907528-b735-af72-b4v6-51c9b3l27960
-    ```
-2. Push the runlogs up to the repository:
+1. Push the runlogs up to the repository:
    ```
-   $ git push origin <experiment-branch-name>
+   $ git push origin HEAD
    ```
 
 !!! warning

--- a/documentation/docs/pages/configs_experiments/fast_track_guidelines.md
+++ b/documentation/docs/pages/configs_experiments/fast_track_guidelines.md
@@ -1,0 +1,111 @@
+# Guidelines for running CMIP7 Assessment Fast Track simulations
+
+This page provides guidelines for community members who will be running ACCESS-ESM1.6 experiments for the [CMIP7 Assessment Fast Track](https://wcrp-cmip.org/cmip-phases/cmip7/fast-track/). As part of the CMIP7 submission, there are requirements around provenance, documentation, and reproducibility, which will impact how your experiments should be run and shared.
+
+This information on this page is fairly general, and ACCESS-NRI/CSIRO staff may provide you with further instructions specific to the experiment that you are running. 
+
+If you haven't volunteered and would be interested in running Assessment Fast Track experiments, please take a look at [this table](https://forum.access-hive.org.au/t/fast-track/1625/7) for a list of the available experiments, and get in contact with Tilo Ziehn.
+
+
+# Prerequisites
+
+1. You will need an [NCI account](https://access-hive.org.au/getting_started/set_up_nci_account) and to [join project vk83](https://my.nci.org.au/mancini/project/vk83/join).
+2. You will need to have completed the [UKMO licensing process](https://forum.access-hive.org.au/t/accessing-ukmo-licensed-models/6168).
+3. You need to have a [GitHub account](https://github.com/) and authenticate it with [GitHub on gadi](https://forum.access-hive.org.au/t/setting-up-gh/4294)
+4. You will need write permissions on the [access-esm1.6-dev-experiments](https://github.com/ACCESS-Community-Hub/access-esm1.6-dev-experiments) GitHub repository. To request access, create a [new issue](https://github.com/ACCESS-Community-Hub/access-esm1.6-dev-experiments/issues) using the *Repository access request* template.
+
+---
+
+# Background information
+This section introduces some background concepts which will be helpful to understand for the instructions and guidelines further below. 
+
+### Payu and running experiments
+ACCESS-ESM1.6 is run using the program [Payu](https://payu.readthedocs.io/en/stable/) via the same commands used for ACCESS-ESM1.5. If you are unfamiliar with running models with Payu or need a refresher, please see [this guide on running ACCESS-ESM1.5](https://docs.access-hive.org.au/models/run_a_model/run_access-esm/) for an introduction (new instructions for ESM1.6 are currently in preparation).
+
+ACCESS-NRI staff will be available, via the ACCESS-Hive Forum, if you have any questions about running the model.
+
+### Configurations and experiments
+#### Configurations
+A Payu *model configuration* contains the complete collection of model settings, configuration files, and paths to input and restart files required to run a model. Payu configurations for ACCESS-ESM1.6 are kept using branches the [access-esm1.6-configs](https://github.com/ACCESS-NRI/access-esm1.6-configs) GitHub repository, with `dev-` branches representing development versions of configurations and `release-` branches representing released configurations.
+
+#### Experiments
+When Payu runs a simulation, it keeps track of the configuration settings, input files, model executables, and restart files used for each run segment and records this information into a git commit in the Payu control directory. This information can be accessed later. For example, the configuration settings used for each segment of the ESM1.6 CMIP7 esm-piControl simulation are available to view [here](https://github.com/ACCESS-Community-Hub/access-esm1.6-dev-experiments/commits/dev-preindustrial%2Bemissions-14-04-26/). This sequence of commits are referred to as the Payu *runlogs*, and as a whole they form a Payu *experiment*.
+
+On completion, ESM1.6 Payu experiments for the CMIP7 Assessment Fast Track will need to be uploaded to the [access-esm1.6-dev-experiments](https://github.com/ACCESS-Community-Hub/access-esm1.6-dev-experiments) GitHub repository.
+
+Payu *configurations* and *experiments* both contain all the information required to run a model, and either can be used to start a simulation.
+
+--- 
+
+# Instructions and guidelines
+## Cloning and running an experiment
+In most cases, ACCESS-NRI and CSIRO will provide you with a branch on the [access-esm1.6-dev-experiments](https://github.com/ACCESS-Community-Hub/access-esm1.6-dev-experiments) GitHub repository which you can clone, run, and push the runlogs back to. 
+
+For example, to clone the *example-experiment* [branch](https://github.com/ACCESS-Community-Hub/access-esm1.6-dev-experiments/tree/example-experiment), you would first load the payu module, and use:
+```
+payu clone git@github.com:ACCESS-Community-Hub/access-esm1.6-dev-experiments.git -B example-experiment <control directory name>
+```
+
+!!! warning
+    If you are cloning an experiment which has been set up for you on the [access-esm1.6-dev-experiments](https://github.com/ACCESS-Community-Hub/access-esm1.6-dev-experiments) GitHub repository, it's important that you don't change the local branch name using the `-b <local-branch-name>` option from the `payu clone` command.*
+
+Once the experiment has been cloned, you can navigate to the control directroy and run it using the usual `payu run -n <n runs>` command.
+
+!!! tip
+    Some experiments will require a more complicated setup, such as scripts that need to be run before the initial simulation. Other experiments may need to be cloned from the [configuration repository](https://github.com/ACCESS-NRI/access-esm1.6-configs) rather than the [experiments repository](https://github.com/ACCESS-Community-Hub/access-esm1.6-dev-experiments). In these cases, ACCESS-NRI staff will provide you with specific instructions.
+
+
+
+## Output syncing
+Model outputs and restarts should be synced to a location on `/g/data` to prevent loss of data during the automatic cleanup of files on `/scratch`. We recommend configuring Payu to automatically sync the outputs and restarts to a location on `/g/data` by enabling the `sync` option in the `config.yaml`:
+
+```diff
+# Sync options for automatically copying data from ephemeral scratch space to
+# longer term storage
+sync:
+-   enable: False # set path below and change to true
++   enable: True # set path below and change to true
+    restarts: True
+    base_path: <Location on /g/data>
+```
+
+With the above changes, Payu will create a new directory matching your experiment's name under the location specified by `base_path`. Outputs and restarts will then be copied to this location at the end of each run segment. For more information on automatic syncing, please see the [Payu documentation](https://payu.readthedocs.io/en/stable/config.html#:~:text=the%20PBS%20script.-,sync,-Sync%20archive%20to).
+
+ACCESS-NRI and CSIRO staff will work with you to determine the best location for syncing your data.
+
+
+## Output archiving
+Output and restart files for ESM1.6 fast track experiments are being archived to the `p73` project. Write access to `p73` is restricted and so CSIRO team members will be in contact with you to organise a data copy upon your simulations' completion.
+
+
+## Pushing completed experiments back to the repository
+Once your simulations are complete, you'll need to push the runlogs back up to the [access-esm1.6-dev-experiments](https://github.com/ACCESS-Community-Hub/access-esm1.6-dev-experiments) GitHub repository using the following steps:
+
+1.  First find the local branch name for each experiment by running the following command in the control directory:
+    ```bash
+    $ payu branch
+    * Current Branch: <experiment-branch-name>
+        experiment_uuid: 3e907528-b735-af72-b4v6-51c9b3l27960
+    ```
+2. Push the runlogs up to the repository:
+   ```
+   $ git push origin <experiment-branch-name>
+   ```
+
+!!! warning
+    If your experiment was originally cloned from the [configuration repository](https://github.com/ACCESS-NRI/access-esm1.6-configs) rather than the [experiments repository](https://github.com/ACCESS-Community-Hub/access-esm1.6-dev-experiments), the above instructions won't apply. ACCESS-NRI staff will provide you with specific instructions in this case.
+
+
+## Crashes, perturbing atmospheric restarts, and reproducibiliy
+
+During the simulations you may run into model crashes. These can occur due to many different reasons including transient errors on Gadi and numerical instabilities in the model, and you're welcome to get in touch with ACCESS-NRI staff or add a [help request](https://forum.access-hive.org.au/t/support-faq-frequently-asked-questions/1021) to the ACCESS-Hive Forum for help with understanding the cause of a creash.
+
+In general, we recommend the following approach for dealing with crashes:
+
+First check the error logs for further information on the error, and try sweeping and rerunning using the payu commands from the experiment control directory:
+```bash
+$ payu sweep
+$ payu run
+```
+
+If the same error occurs on the rerun, it may be due to a numerical instability and you can try perturbing the atmosphere restart file as a workaround. It's crucial to do this in a reproducible way and to keep a record of any perturbations applied. We recommend following the steps [outlined here](/inputs/restarts/#perturbing-an-atmospheric-restart-file), which will apply a reproducible perturbation and record it in the experiment runlogs.

--- a/documentation/docs/pages/inputs/restarts.md
+++ b/documentation/docs/pages/inputs/restarts.md
@@ -74,13 +74,19 @@ We recommend using the following steps to apply and record a perturbation:
    $ python ~access/apps/pythonlib/umfile_utils/access_cm2/perturbIC.py -s <SEED> <path to restartXYZ>/atmosphere/restart_dump.astart
    ```
    here `<SEED>` can be any integer, and it's used to set the [random seed](https://en.wikipedia.org/wiki/Random_seed) for the perturbation. Specifying a random seed is important, as it allows for the exact same perturbation to be reapplied in the future. Make sure to keep track of whichever value you use.
-3. Make a record of the perturbation in the experiment runlogs. First navigate to the Payu control directory for the experiment and then run
+3. Make a record of the perturbation in the experiment runlogs. First `cd` into the Payu control directory for the experiment and run
+   ```
+   payu setup
+   ```
+   This will rewrite the manifest file using the data from the modified restart. To record the pertubation in the experiment history, next run
    ```bash
-   $ git commit --allow-empty -m "restartXYZ perturbed using command:  python ~access/apps/pythonlib/umfile_utils/access_cm2/perturbIC.py -s <SEED> <path to restartXYZ>/atmosphere/restart_dump.astart"
+   $ git commit -a -m "restartXYZ perturbed using command:  python ~access/apps/pythonlib/umfile_utils/access_cm2/perturbIC.py -s <SEED> <path to restartXYZ>/atmosphere/restart_dump.astart"
    ```
    filling in the correct information for `<SEED>` and `<path to restartXYZ>`. When the experiment is uploaded to the experiments repository, it will include this record of the applied perturbation.
 
    If you run the `git log` command, it should now include the above record.
+
+   You will finally need to run `payu sweep` to clear the work directory before setting off the next run.
 
 
 ### Changing the date of restart files

--- a/documentation/docs/pages/inputs/restarts.md
+++ b/documentation/docs/pages/inputs/restarts.md
@@ -52,6 +52,37 @@ a2i.nc  i2a.nc  o2i.nc
 
 ## Common restart manipulations
 
+### Perturbing an atmospheric restart file
+
+ESM1.6 simulations occasionally crash due to numerical instabilities in the atmosphere component. A common workaround is to apply a small perturbation to the theta field in the last atmospheric restart file.  
+
+It's best practice to apply the perturbation in a reproducible way, and to record details of any perturbations that are added during your experiment. Doing so will allow you to rerun the same experiment in an identical way in the future, for example to enable additional output variables. 
+
+We recommend using the following steps to apply and record a perturbation:
+
+
+!!! warning
+    Before applying a perturbation, we recommend first inspecting the error logs and trying to sweep and rerun to rule out other problems such as transient errors on Gadi.
+
+
+1. In the experiment's archive directory, first make a backup of the latest restart directory (e.g. `restartXYZ`). 
+   ```bash
+   $ cp -r restartXYZ backup_restartXYZ
+   ```
+2. With the payu module loaded, apply a perturbation to the latest atmosphere restart:
+   ```bash
+   $ python ~access/apps/pythonlib/umfile_utils/access_cm2/perturbIC.py -s <SEED> <path to restartXYZ>/atmosphere/restart_dump.astart
+   ```
+   here `<SEED>` can be any integer, and it's used to set the [random seed](https://en.wikipedia.org/wiki/Random_seed) for the perturbation. Specifying a random seed is important, as it allows for the exact same perturbation to be reapplied in the future. Make sure to keep track of whichever value you use.
+3. Make a record of the perturbation in the experiment runlogs. First navigate to the Payu control directory for the experiment and then run
+   ```bash
+   $ git commit --allow-empty -m "restartXYZ perturbed using command:  python ~access/apps/pythonlib/umfile_utils/access_cm2/perturbIC.py -s <SEED> <path to restartXYZ>/atmosphere/restart_dump.astart"
+   ```
+   filling in the correct information for `<SEED>` and `<path to restartXYZ>`. When the experiment is uploaded to the experiments repository, it will include this record of the applied perturbation.
+
+   If you run the `git log` command, it should now include the above record.
+
+
 ### Changing the date of restart files
 
 It's commonly required to change the date for a restart file. For example when setting up a historical experiment, a restart might be taken from a pre-industrial simulation and the date changed to 1850. Another example is when combining ocean and atmosphere restarts from two different experiments into a single restart, where it is necessary to make sure the dates for the different components match.

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -33,6 +33,7 @@ nav:
   - Configurations and Experiments:
         - Configuration:    pages/configs_experiments/overviewconfiguration.md
         - Experiments:    pages/configs_experiments/experiments.md
+        - Running Fast Track experiments: pages/configs_experiments/fast_track_guidelines.md
 
   - Diagnostics:
         - Sea Ice: pages/diagnostics/sea_ice.md # do not edit directly, change 


### PR DESCRIPTION
Closes #840

This draft PR adds guidelines for community members who will be running additional CMIP7 Fast Track experiments, covering topics including prerequisites, background concepts, setting up experiments, archiving data, and pushing back to the experiments repository. The goal is to cover the information needed for adhering to the provenance and reproducibility requirements for the fast track experiments.  

It only covers the simplest case, where we've set up branches on the experiment repository for the person running the experiments to clone and run. This should be the most common situation, and in more complex cases I think it will be better for us to provide specific instructions to the person directly, rather than trying to cover several different cases all in the one document and risk confusing everyone else.

I've kept this as a draft, while we wait for an updated perturbation script to be available on `vk83`. The other sections should be ready for review, and any feedback/suggestions are welcome! 