### PR TITLE
Add script to setup amip restart from 1978 historical restart

### DIFF
--- a/scripts/setup_amip_restart.py
+++ b/scripts/setup_amip_restart.py
@@ -1,0 +1,113 @@
+import argparse
+import git
+from ruamel.yaml import YAML
+from pathlib import Path
+import shutil
+import shlex
+import subprocess
+import re
+import tempfile
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Copy and modify a 1978 ESM1.6 historical restart directory for use as the"
+            "initial condition in an amip simulation. This includes:\n"
+            " - Removing the ocean, ice, and coupler restart files\n"
+            " - Removing coupling fields from the atmosphere restart dump\n"
+            "The initial restart path is taken from the config.yaml, and the output restart path is specified as an argument."
+        ),
+        formatter_class=argparse.RawTextHelpFormatter
+    )
+    parser.add_argument(
+        '--output-restart',
+        help='Path for saving modified output ESM1.6 restart directory. Defaults to archive/initial_restart.',
+        type=Path,
+        required=False
+        )
+
+    return parser.parse_args()
+
+
+def remove_non_atm_restarts(restart_dir):
+    """Remove restart files for the non-atmosphere components."""
+    shutil.rmtree(restart_dir / "ocean")
+    shutil.rmtree(restart_dir / "ice")
+    shutil.rmtree(restart_dir / "coupler")
+
+
+def subset_atmosphere_restart(restart_dump):
+    """Remove coupling fields from a UM restart. Replaces the input file."""
+    exclude_list = "95,171,172,173,174,176,177,178,179,180,181,184,185,186,187,188,189,192,250,413,414,415,416,33001,33002"
+    tmp = tempfile.NamedTemporaryFile()
+    cmd = f"python scripts/um_fields_subset.py {restart_dump} --exclude {exclude_list} --output {tmp}"
+    subprocess.check_call(shlex.split(cmd))
+    shutil.copy(tmp, restart_dump)
+
+
+def get_archive_path():
+    """Get the archive path for the current experiment."""
+    repo = git.Repo(".")
+    current_branch = repo.active_branch.name
+
+    cmd = f"payu checkout {current_branch}"
+    checkout_output = subprocess.run(shlex.split(cmd), check=True, capture_output=True, text=True).stdout
+
+    pattern = r"\nAdded archive symlink to (?P<archive>.*)\n"
+    if match := re.search(pattern, checkout_output):
+        archive_path = Path(match.group('archive'))
+    else:
+        raise RuntimeError("Unable to get experiment archive path.")
+
+    return archive_path
+
+
+def copy_restart(input, output):
+    """Copy the input restart directory to the specified output location"""
+    if output.exists():
+        raise FileExistsError(f"Output path {output} already exists.")
+
+    print(f"Copying {input} to {output}")
+    shutil.copytree(input, output)
+
+
+def update_config(restart_dir, config):
+    """Update the restart path in the config.yaml"""
+    print("Updating config.yaml with new restart path")
+    config["restart"] = str(restart_dir)
+    YAML().dump(config, Path("config.yaml"))
+
+
+def commit_config(input_restart, output_restart):
+    """Commit changes to the config.yaml"""
+    repo = git.Repo(".")
+    repo.index.add("config.yaml")
+    msg = (
+        f"Restarts in {input_restart} copied to {output_restart} and modified\n"
+        f"using {Path(__file__).name}\n"
+        " * Ocean, sea ice and coupler restart files removed.\n"
+        " * Coupling fields removed from atmosphere restart file.\n"
+    )
+    print(f"Commiting changes to config.yaml with message: '{msg}'")
+    repo.index.commit(msg)
+
+
+if __name__ == "__main__":
+    args = parse_args()
+
+    output_restart = args.output_restart
+    if output_restart is None:
+        output_restart = get_archive_path() / "initial_restart"
+
+    output_restart = output_restart.resolve()
+
+    config = YAML().load(Path("config.yaml"))
+    input_restart = config["restart"]
+    copy_restart(input_restart, output_restart)
+
+    remove_non_atm_restarts(output_restart)
+    subset_atmosphere_restart(output_restart / "atmosphere" / "restart_dump.astart")
+
+    update_config(output_restart, config)
+    commit_config(input_restart, output_restart)

--- a/scripts/setup_amip_restart.py
+++ b/scripts/setup_amip_restart.py
@@ -41,9 +41,10 @@ def subset_atmosphere_restart(restart_dump):
     """Remove coupling fields from a UM restart. Replaces the input file."""
     exclude_list = "95,171,172,173,174,176,177,178,179,180,181,184,185,186,187,188,189,192,250,413,414,415,416,33001,33002"
     tmp = tempfile.NamedTemporaryFile()
-    cmd = f"python scripts/um_fields_subset.py {restart_dump} --exclude {exclude_list} --output {tmp}"
+    cmd = f"python scripts/um_fields_subset.py {restart_dump} --exclude {exclude_list} --output {tmp.name}"
+    print(cmd)
     subprocess.check_call(shlex.split(cmd))
-    shutil.copy(tmp, restart_dump)
+    shutil.copy(tmp.name, restart_dump)
 
 
 def get_archive_path():

--- a/scripts/setup_amip_restart.py
+++ b/scripts/setup_amip_restart.py
@@ -12,7 +12,7 @@ import tempfile
 def parse_args():
     parser = argparse.ArgumentParser(
         description=(
-            "Copy and modify a 1978 ESM1.6 historical restart directory for use as the"
+            "Copy and modify a 1978 ESM1.6 historical experiment restart directory for use as the"
             "initial condition in an amip simulation. This includes:\n"
             " - Removing the ocean, ice, and coupler restart files\n"
             " - Removing coupling fields from the atmosphere restart dump\n"
@@ -31,14 +31,15 @@ def parse_args():
 
 
 def remove_non_atm_restarts(restart_dir):
-    """Remove restart files for the non-atmosphere components."""
+    """Remove restart files for the ocean, ice and coupler."""
     shutil.rmtree(restart_dir / "ocean")
     shutil.rmtree(restart_dir / "ice")
     shutil.rmtree(restart_dir / "coupler")
 
 
 def subset_atmosphere_restart(restart_dump):
-    """Remove coupling fields from a UM restart. Replaces the input file."""
+    """Remove coupling fields from a UM restart. Changes file in place."""
+    # See https://forum.access-hive.org.au/t/create-an-amip-restart-from-a-coupled-restart/5261 for backround
     exclude_list = "95,171,172,173,174,176,177,178,179,180,181,184,185,186,187,188,189,192,250,413,414,415,416,33001,33002"
     tmp = tempfile.NamedTemporaryFile()
     cmd = f"python scripts/um_fields_subset.py {restart_dump} --exclude {exclude_list} --output {tmp.name}"
@@ -88,7 +89,7 @@ def commit_config(input_restart, output_restart):
         f"Restarts in {input_restart} copied to {output_restart} and modified\n"
         f"using {Path(__file__).name}\n"
         " * Ocean, sea ice and coupler restart files removed.\n"
-        " * Coupling fields removed from atmosphere restart file.\n"
+        " * Coupling fields removed from atmosphere restart file."
     )
     print(f"Commiting changes to config.yaml with message: '{msg}'")
     repo.index.commit(msg)

--- a/scripts/um_fields_subset.py
+++ b/scripts/um_fields_subset.py
@@ -15,7 +15,11 @@ import warnings
 from textwrap import dedent
 from itertools import chain
 
-PROGNOSTIC_STASH_CODES = tuple(chain(range(1,999+1), range(33001,34999+1)))
+# Prognostic variables have section 0, 33 (tracers), or 34 (UKCA).
+# Tracer flux variables 3100 - 3129 are also treated as prognostic.
+PROGNOSTIC_STASH_CODES = tuple(chain(range(1,999+1), range(3100,3129+1), range(33001,34999+1), range(54000,54999+1)))
+# Tracer variables have section 33
+TRACER_STASH_CODES = tuple(range(33000, 33999+1))
 
 def convert_to_list(value: str):
     """
@@ -216,7 +220,111 @@ def filter_fieldsfile(input_file, prognostic, include_list, exclude_list):
 
     filtered_file.fields = include_fields(input_file.fields, include_list) if include_list is not None else exclude_fields(input_file.fields, exclude_list)
     return filtered_file
+
+
+def update_prognostic_count(fields_file):
+    """
+    Update the count of prognostic variables in a file's fixed length header.
+
+    Parameters
+    ----------
+    field: mule.ff.FieldsFile
+        mule fields file to be updated.
+
+    Returns
+    -------
+    None
+    """
+    previous_count = fields_file.fixed_length_header.total_prognostic_fields
+    updated_count = sum([is_prognostic(field) and is_instantaneous(field) for field in fields_file.fields])
+    if updated_count != previous_count:
+        print(f"Resetting no. of prognostic fields from {previous_count} to {updated_count}")
+        fields_file.fixed_length_header.total_prognostic_fields = updated_count
+
+
+def is_prognostic(field):
+    """
+    Check whether a field is a prognostic variable.
+
+    Parameters
+    ----------
+    field: mule.Field
+        The mule field to be checked
+
+    Returns
+    -------
+    bool
+        Whether the field is prognostic or not.
+    """
+    return field.lbuser4 in PROGNOSTIC_STASH_CODES
+
+
+def is_instantaneous(field):
+    """
+    Check that a field is instantaneous with no time aggregation or processing.
+
+    Parameters
+    ----------
+    field: mule.Field
+
+    Returns
+    -------
+    bool
+        whether a field is instantaneous.
+    """
+    # Check the field is instantaneous (lbtime < 10).
+    # Check the field has no time processing (lbproc == 0).
+    # Check the field is not a timeseries (lbcode < 30000).
+    return field.lbtim < 10 and field.lbproc == 0 and field.lbcode < 30000
+
+
+def update_tracer_count(fields_file):
+    """
+    Update the count of instantaneous tracer variables in a file's fixed length header.
+
+    Parameters
+    ----------
+    field: mule.ff.FieldsFile
+        mule fields file to be updated.
+
+    Returns
+    -------
+    None
+    """
+    previous_count = fields_file.integer_constants.num_passive_tracers
+    num_tracer_fields = sum([is_tracer(field)  and is_instantaneous(field) for field in fields_file.fields])
+    # Divide by number of levels for the number of tracer variables
+    if num_tracer_fields % fields_file.integer_constants.num_tracer_levels !=0:
+        raise ValueError(
+            f"Number of tracer levels {fields_file.integer_constants.num_tracer_levels} "
+            f"does not divide number of tracer fields {num_tracer_fields}. Number of "
+            "tracer variables cannot be determined."
+        )
+
+    updated_count = num_tracer_fields / fields_file.integer_constants.num_tracer_levels
+
+    if updated_count != previous_count:
+        print(f"Resetting no. of tracer fields from {previous_count} to {updated_count}")
+        fields_file.integer_constants.num_passive_tracers = updated_count
+
+
+
+def is_tracer(field):
+    """
+    Check that a field is a tracer field.
+    Parameters
+    ----------
+    field: mule.Field
+
+    Returns
+    -------
+    bool
+        whether a field is a tracer.
+    """
+    return field.lbuser4 in TRACER_STASH_CODES
     
+
+
 def main():
 
     # Parse the inputs and validate that they do not xlist or vlist are given.
@@ -233,6 +341,9 @@ def main():
     # Skip mule validation if the "--validate" option is not provided
     if not args.validate:
         filtered_file.validate = void_validation
+
+    update_prognostic_count(filtered_file)
+    update_tracer_count(filtered_file)
 
     filtered_file.to_file(output_filename)
 

--- a/scripts/um_fields_subset.py
+++ b/scripts/um_fields_subset.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python
+# Select a subset from a UM fieldsfile
+# -p option will select only the prognostic fields required for an initial
+# dump and will also check some header fields.
+
+# Output word size and endianness match input.
+
+# This doesn't change the "written" date in a dump header.
+# Martin Dix martin.dix@csiro.au
+
+import mule
+import os
+import argparse
+import warnings
+from textwrap import dedent
+from itertools import chain
+
+PROGNOSTIC_STASH_CODES = tuple(chain(range(1,999+1), range(33001,34999+1)))
+
+def convert_to_list(value: str):
+    """
+    Convert a comma-separated string into a list of positive integers.
+    
+    Parameters
+    __________
+    value: str
+    A string of comma-separated positive integers
+
+    Returns
+        list
+        A list of STASH codes to be excluded or included
+    
+    """
+    msg = "All values must be positive integers."
+    try:
+        values = [int(v) for v in value.split(",")]
+        if any(v <= 0 for v in values):
+            raise ValueError(msg)
+        return values
+    except ValueError:
+        raise argparse.ArgumentTypeError(msg)
+        
+def parse_args():
+    """
+    Parse command-line arguments.
+
+    Parameters
+    ----------
+    None
+
+    Returns
+    ----------
+    args_parsed : argsparse.Namespace
+        Argparse namespace containing the parsed command line arguments.
+    """
+    DESCRIPTION = dedent(
+        """
+        Subset a UM file to generate an output containing only selected fields. 
+        
+        Examples:
+        
+        1. Subset UM file only including STASH codes 155, 156, 3100 and 3101
+        `um_fields_subset /path/to/um/file --include 155,156,3100,3101`
+        
+        2. Subset UM file excluding the STASH codes 132 and 14020
+        `um_fields_subset /path/to/um/file --exclude 132,14020`
+        
+        2. Subset UM file only including prognostic STASH codes
+        `um_fields_subset /path/to/um/file -p`
+        """
+    )
+    parser = argparse.ArgumentParser(description=DESCRIPTION, formatter_class=argparse.RawDescriptionHelpFormatter)
+
+    # Positional arguments
+    parser.add_argument(dest='ifile', metavar="INPUT_PATH", help='Path to the input file.')
+    # Optional arguments
+    parser.add_argument('-o', '--output', dest = 'output_path', metavar="OUTPUT_PATH", help='Path to the output file. If omitted, the default output file is created by appending "_subset" to the input path.')
+    meg = parser.add_mutually_exclusive_group(required=True)
+    meg.add_argument('-p', '--prognostic', dest='prognostic',  action='store_true',
+                        help="Only include prognostic variables (sections 0, 33 and 34). Cannot be used together with --include or --exclude.")
+    meg.add_argument('--include', dest='include_list',  type=convert_to_list, metavar="STASH_CODES",
+                        help="Comma-separated list of STASH codes to include in the output file. Any STASH code present in the input file but not contained in this STASH code list will not be present in the output file. Cannot be used together with --prognostic or --exclude.")
+    meg.add_argument('--exclude', dest='exclude_list',  type=convert_to_list, metavar="STASH_CODES",
+                        help="Comma-separated list of STASH codes to exclude from the output file. All STASH codes present in the input file but not contained in this STASH code list will be present in the output file. Cannot be used together with --prognostic or --include.")
+    parser.add_argument('--validate', action='store_true',
+                        help='Validate the output fields file using mule validation.')
+    # Parse arguments
+    args_parsed = parser.parse_args()
+    
+    # Return arguments
+    return args_parsed
+
+
+def void_validation(*args, **kwargs):
+    """
+    Don't perform the validation, but print a message to inform that validation has been skipped.
+    """
+
+    print('Skipping mule validation. To enable the validation, run using the "--validate" option.')
+
+
+def create_default_outname(filename, suffix="_subset"):
+    """
+    Create a default output filename by appending a suffix to the input filename.
+    If an output filename already exists, a number will be appended to produce a unique output filename.
+
+    Parameters
+    ----------
+    filename: str
+         The input filename.
+    suffix: str, optional
+        The suffix to append to the filename.
+
+    Returns
+    ----------
+    output_filename: str
+        The default output filename.
+    """
+
+    output_filename = f"{filename}{suffix}"
+    num=""
+    if os.path.exists(output_filename):
+        num = 1
+        while os.path.exists(f"{output_filename}{num}"):
+            num += 1
+    return f"{output_filename}{num}"
+    
+def warn_if_stash_not_present(fields, stash_list):
+    """
+    Raise a warning for any stash codes included in the input stash_list that are not present within the input fields.
+    
+    Parameters
+    __________
+
+    fields : mule.ff.FieldsFile.fields
+        All the fields from the fields file.
+
+    stash_list :  set of int
+    Returns
+    _______
+        None
+
+    """
+
+    existing_codes = {f.lbuser4 for f in fields}
+    missing_codes = set(stash_list) - existing_codes
+
+    if missing_codes:
+        warnings.warn(f"The following STASH codes are not found in the input file: {missing_codes}")
+
+
+def include_fields(fields, stash_list):
+    """
+    Return a subset of the input fields, containing only the ones having a stash code included in stash_list. Raise a warning if a stash code included in stash_list is not present in the input fields.
+
+    Parameters
+    __________
+    fields : mule.ff.FieldsFile.fields 
+        All the fields from the fields file.
+    stash_list : list of int
+        A list of STASH item codes to include.
+    
+    Returns
+    -------
+        list of mule.ff.FieldsFile.fields
+        The subset of fields only containing the ones to be included.
+    """
+
+    warn_if_stash_not_present(fields, stash_list)
+    return [f.copy() for f in fields if f.lbuser4 in stash_list]
+
+def exclude_fields(fields, stash_list):
+    """
+    Return a subset of the input fields, containing only the ones having a stash code not included in stash_list. Raise a warning if a stash code included in stash_list is not present in the input fields.
+
+    Parameters
+    __________
+    fields : mule.ff.FieldsFile.fields 
+        All the fields from the fields file.
+    stash_list : list of int
+        A list of STASH item codes to exclude.
+    
+    Returns
+    -------
+        list of mule.ff.FieldsFile.fields
+        The subset of fields not containing the ones to be excluded.
+    """
+
+    warn_if_stash_not_present(fields, stash_list)
+    return [f.copy() for f in fields if f.lbuser4 not in stash_list]
+
+def filter_fieldsfile(input_file, prognostic, include_list, exclude_list):
+    """
+    Creates a new mule fieldsfile from the input_file, by filtering its fields based on the values of prognostic, include_list and eclude_list.
+
+    Parameters
+    ----------
+    input_file : mule.ff.FieldsFile
+        The mule fieldsfile to be filtered.
+    prognostic : bool
+        A boolean flag indicating if only prognostic fields should be included.
+    include_list : list of int or None
+        A list of STASH item codes to include.
+    exclude_list : list of int or None
+        A list of STASH item codes to exclude.
+
+    Returns
+    -------
+    filtered_file : mule.ff.FieldsFile
+        The filtered mule fieldsfile.
+    """
+
+    filtered_file = input_file.copy()
+    if prognostic:
+        include_list = PROGNOSTIC_STASH_CODES
+
+    filtered_file.fields = include_fields(input_file.fields, include_list) if include_list is not None else exclude_fields(input_file.fields, exclude_list)
+    return filtered_file
+    
+def main():
+
+    # Parse the inputs and validate that they do not xlist or vlist are given.
+    args = parse_args()
+
+    # Create the output filename.
+    output_filename = create_default_outname(args.ifile) if args.output_path is None else args.output_path
+    
+    ff = mule.DumpFile.from_file(args.ifile)
+
+    # filter the fieldsfile
+    filtered_file = filter_fieldsfile(ff, args.prognostic, args.include_list, args.exclude_list)
+
+    # Skip mule validation if the "--validate" option is not provided
+    if not args.validate:
+        filtered_file.validate = void_validation
+
+    filtered_file.to_file(output_filename)
+
+if __name__== "__main__":
+    main() # pragma: no cover


### PR DESCRIPTION
<!-- This template was created to cover the most complex case of new changes to the configuration. As such, all sections may not be suitable for other types of changes (e.g. documentation changes, cherry-picking changes between configurations). Please fill in all the sections you believe are suitable to your case. The reviewer(s) will ask for any missing information. Please do not delete any empty sections. -->

**1. Summary**:

AMIP experiments branch off the 1978 restart files produced by historical experiments. Before running, the initial restart needs to be modified for compatibility with the AMIP configuration:
- Ocean, coupler, and sea ice files can be removed. This is might not be 100% necessary but it does simplify the initial restart manifest.
- Coupling related fields need to be removed from the atmosphere restart, following the process in step 2 [here](https://forum.access-hive.org.au/t/create-an-amip-restart-from-a-coupled-restart/5261)

Following discussions, we decided to follow the approach from the historical and esm-historical configurations for modifying the initial restart. Those configurations contain a script which can be run by the user, which:
- copy the restart specified in the config.yaml to the archive directory
- apply modifications to the copied restart
- change the path in the config.yaml to point to the modified restart, and commit the change to the runlogs with a descriptive message.
The default restart in those configurations already contain the modifications, and so the script is only necessary when using a different restart.


This PR add s a script which performs the above steps to the amip configuration.


**2. Issues Addressed:**
<!-- Add links to github issue(s) this is related to -->
- #827

**3. Dependencies (e.g. on payu, or model)**

This change requires changes to (note pull request(s) where relevant):
- [ ] workflow manager (payu):
- [ ] model deployment (ACCESS-ESM1.6):
- [ ] model component or library dependency:
- [ ] input workflow:

<!-- Describe and link to the related changes to dependencies -->

**4. Ad-hoc Testing**

Comparing two one year runs. The first used the scripts to modify the initial restart, which was first copied from the historical simulation. For the second, I manually modified the restart following step 2 [here](https://forum.access-hive.org.au/t/create-an-amip-restart-from-a-coupled-restart/5261).

Outputs are identical at the end of the year:
```
nccmp -dgf manual-restart-comparison/archive/output000/atmosphere/netCDF/aiihca.pa-197812_mon.nc update-um_fields_subset//archive/output000/atmosphere/netCDF/aiihca.pa-197812_mon.nc 
```



**5. CI Testing**
<!-- Has the CI-testing been run? -->
- [ ] `!test repro` has been run

**6. Reproducibility**

Is this reproducible with the previous commit? (If not, why not?)
- [ ] Yes
- [ ] No - `!test repro commit` has been run. <!-- add detail below for why it's answer changing -->

**7. Performance**
<!-- check the throughput of the model by running 6 months with and without your changes and recording the walltime-->

Has the model performance (say, throughput of model-years/wall-day) changed? 
- [ ] Yes
- [ ] No
- [ ] N/A (if selected, please add a brief explanation why performance testing is not necessary for this PR)

If yes, provide the numbers from your testing. Is the performance better or worse?

**8. Manifests**

Have you changed the executable, the input files and/or the restart files?
- [ ] Yes
- [ ] No

If yes, have you updated the manifests?
- [ ] Yes
- [ ] No

To update the manifests, run payu setup (in a cloned copy of your feature branch) with reproducibility tests turned off:

```yaml
manifest:
  reproduce:
    exe: false
    input: false
    restart: false
runlog:
  enable: false
```
Then commit the newly created manifest files (under manifests/) only to the branch for this PR.


**9. Documentation**
<!--Does this impact documentation? -->

Is the documentation updated?
- [ ] Yes
- [ ] N/A

**10. Merge Strategy**
<!-- What is the planned merge strategy (Merge commit, Rebase and merge, or squash) ?
If not squash, link to the related issue in the commit descriptions -->

- [ ] Merge commit
- [ ] Rebase and merge
- [ ] Squash
