### PR TITLE
ci.json: use dev_config marker on dev configs

### DIFF
--- a/config/ci.json
+++ b/config/ci.json
@@ -2,14 +2,14 @@
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/configuration/ci/2-0-0.json",
     "scheduled": {
         "default": {
-            "markers": "(repro and (not repro_restart)) or access_esm1p6 or config"
+            "markers": "(repro and (not repro_restart)) or access_esm1p6 or dev_config"
         },
-        "dev-preindustrial+concentrations": { },
-        "dev-4xCO2+concentrations": { },
+        "dev-piControl": { },
+        "dev-abrupt-4xCO2": { },
         "dev-1pctCO2": { },
-        "dev-historical+concentrations": { },
-        "dev-preindustrial+emissions": { },
-        "dev-flat10": { },
+        "dev-historical": { },
+        "dev-esm-historical": { },
+        "dev-esm-flat10": { },
         "dev-amip": { },
         "dev-1pctCO2-rad": { },
         "dev-1pctCO2-bgc": { }

--- a/config/ci.json
+++ b/config/ci.json
@@ -25,9 +25,10 @@
     },
     "qa": {
         "default": {
-            "markers": "access_esm1p6 or config"
+            "markers": "access_esm1p6 or dev_config"
         },
          "release-.*": {
+            "markers": "access_esm1p6 or config",
             "model-config-tests-version": "0.2.3",
             "payu-version": "1.3.0"
         }


### PR DESCRIPTION
This PR updates the `ci.json` so that the QA test CI runs the `dev_config` marker on non-`release-*` configs, rather than the `config` marker.