### PR TITLE
Add group read permissions to restarts after modification

### DIFF
--- a/scripts/insert_external_woodprod_CNP.py
+++ b/scripts/insert_external_woodprod_CNP.py
@@ -6,6 +6,7 @@ import six
 import shutil
 import tempfile
 import os
+import stat
 
 
 def parse_args():
@@ -124,6 +125,11 @@ def insert_woodprod(restart_path, external_nc_path, stashmaster_base_path, stash
 
     ff.to_file(ff, tmp.name)
     shutil.copy(tmp.name, output_path)
+
+    # tempfiles only have user read+write permissions.
+    # Set user read+write and group read permission
+    os.chmod(output_path, stat.S_IREAD | stat.S_IWRITE | stat.S_IRGRP)
+
     print(f"Modified restart file written to '{output_path}'")
 
 

--- a/scripts/update_landuse.py
+++ b/scripts/update_landuse.py
@@ -20,6 +20,7 @@ import mule
 import xarray
 import os
 import shutil
+import stat
 import sys
 import tempfile
 
@@ -70,3 +71,7 @@ temp = tempfile.NamedTemporaryFile()
 out.to_file(temp.name)
 
 shutil.copy(temp.name, restart)
+
+# tempfiles only have user read+write permissions.
+# Set user read+write and group read permission
+os.chmod(restart, stat.S_IREAD | stat.S_IWRITE | stat.S_IRGRP)

--- a/scripts/update_thinning.py
+++ b/scripts/update_thinning.py
@@ -4,7 +4,9 @@ import um_replace_field
 import xarray
 import argparse
 import tempfile
+import os
 import shutil
+import stat
 
 def _parse_args():
     parser = argparse.ArgumentParser(
@@ -58,6 +60,10 @@ def insert_thinning(restart_file, thinning_file, stashmaster_file):
         )
 
     shutil.copy(tmp.name, restart_file)
+
+    # tempfiles only have user read+write permissions.
+    # Set user read+write and group read permission
+    os.chmod(restart_file, stat.S_IREAD | stat.S_IWRITE | stat.S_IRGRP)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- This template was created to cover the most complex case of new changes to the configuration. As such, all sections may not be suitable for other types of changes (e.g. documentation changes, cherry-picking changes between configurations). Please fill in all the sections you believe are suitable to your case. The reviewer(s) will ask for any missing information. Please do not delete any empty sections. -->

**1. Summary**:
See #855 for further background. 

The `update_landuse.py` and `update_thinning.py` userscripts run at the end of each model run. They make changes to the end of run atmosphere restart by creating a temporary file, writing the modified restart data to it, and then moving the temporary file so that it overwrites the restart produced by the model.

Python's `tempfile` only creates files with user read and write permissions, while the model writes restarts with user read+write and group read permissions. This causes issues when syncing data – the restarts are omitted if someone else runs the syncing, or otherwise they generally aren't readable for anyone else.


This PR adds a step to these scripts which adds group read permissions to the modified restart file. It also adds this change to the `insert_external_woodprod_CNP.py` script used for setting up initial historical restarts.

**2. Issues Addressed:**
<!-- Add links to github issue(s) this is related to -->
- #855 

**3. Dependencies (e.g. on payu, or model)**

This change requires changes to (note pull request(s) where relevant):
- [ ] workflow manager (payu):
- [ ] model deployment (ACCESS-ESM1.6):
- [ ] model component or library dependency:
- [ ] input workflow:

<!-- Describe and link to the related changes to dependencies -->

**4. Ad-hoc Testing**


With the changes, each script writes files with the desired permissions:
```
-rw-r----- 1 sw6175 tm70 1299779584 Jul 17 14:26 landuse_restart
-rw-r----- 1 sw6175 tm70 1299779584 Jul 17 14:27 thinning_restart
-rw-r----- 1 sw6175 tm70 1299779584 Jul 17 14:30 woodprod_restart
```

Restarts produced are otherwise identical using the modified vs unmodified code.

**5. CI Testing**
<!-- Has the CI-testing been run? -->
- [x] `!test repro` has been run

**6. Reproducibility**

Is this reproducible with the previous commit? (If not, why not?)
- [x] Yes
- [ ] No - `!test repro commit` has been run. <!-- add detail below for why it's answer changing -->

**7. Performance**
<!-- check the throughput of the model by running 6 months with and without your changes and recording the walltime-->

Has the model performance (say, throughput of model-years/wall-day) changed? 
- [ ] Yes
- [ ] No
- [x] N/A (if selected, please add a brief explanation why performance testing is not necessary for this PR)

Only changes file permissions. Should not affect performance

**8. Manifests**

Have you changed the executable, the input files and/or the restart files?
- [ ] Yes
- [x] No

If yes, have you updated the manifests?
- [ ] Yes
- [ ] No

To update the manifests, run payu setup (in a cloned copy of your feature branch) with reproducibility tests turned off:

```yaml
manifest:
  reproduce:
    exe: false
    input: false
    restart: false
runlog:
  enable: false
```
Then commit the newly created manifest files (under manifests/) only to the branch for this PR.


**9. Documentation**
<!--Does this impact documentation? -->

Is the documentation updated?
- [ ] Yes
- [x] N/A

**10. Merge Strategy**
<!-- What is the planned merge strategy (Merge commit, Rebase and merge, or squash) ?
If not squash, link to the related issue in the commit descriptions -->

- [ ] Merge commit
- [ ] Rebase and merge
- [x] Squash
