### PR TITLE
Update to cherry pick instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,17 +50,3 @@ More information on submitting a Pull Request and on the specifics of this pipel
 
 For more information on the manually running the pytests that are run as part of the reproducibility CI checks, see
 [model-config-tests](https://github.com/ACCESS-NRI/model-config-tests/).
-
-## Automated Cherry Picking
-
-There is a workflow which enables semi-automated cherry-picking from one branch into another, using the !cherry-pick keyword in a pull-request. This is useful when a change needs to be applied across multiple branches.
-
-For example, if a pull-request changes `dev-preindustrial+concentrations`, to apply the change to `dev-4xCO2+concentrations`:
-- First finalise and merge the pull-request into `dev-preindustrial+concentrations`
-- Second, as a standalone comment in the pull-request, use the keyword as follows:
-    ` !cherry-pick <commit> into <branch> `
-
-\<commit> must exist in `dev-preindustrial+concentrations`. This can be one or multiple commit hashes seperated by spaces.
-\<branch> would be `dev-4xCO2+concentrations` in this example
-
-This will attempt to make a new pull-request with the request commit(s), and leave a comment on the initial-pull request with the outcome.

--- a/documentation/docs/pages/infrastructure/git-practices.md
+++ b/documentation/docs/pages/infrastructure/git-practices.md
@@ -5,17 +5,17 @@
 There is a workflow which enables semi-automated cherry-picking from one branch into another, using the !cherry-pick keyword in a pull-request. This is useful when changes need to be applied across multiple branches.
 
 For example, if you have made a pull request into `dev-piControl` and want to duplicate the changes in `dev-esm-piControl`:
+
 1. First organise your changes into a neat set of commits, and merge the pull request into `dev-piControl`.
-2. Identify the newly created commits in `dev-piControl` which you want to copy over to `dev-esm-piControl`, e.g. `hash1`, `hash2`, ..., `hashn`. This could be all, or just a subset of the commits created by merging the PR, depending on which specific changes you want to copy over. Omit any merge commits from this list, as they are not supported by the automatic cherry pick command.
-3. In a new comment in the just merged PR, use the `!cherry-pick` command as follows:
-    `!cherry-pick hash1 hash2 <...> hashn into dev-esm-piControl`
+2. Identify the commits in `dev-piControl` which you want to copy over to `dev-esm-piControl`, e.g. `hash1`, `hash2`, ..., `hashn`. This could be all, or just a subset of the commits created by merging the PR, depending on which specific changes you want to copy over. Omit any merge commits from this list, as they are not supported by the automatic cherry pick command.
+3. In a new comment in the just merged PR, use the `!cherry-pick` command as follows:    `!cherry-pick hash1 hash2 <...> hashn into dev-esm-piControl`
 
 This will create a new PR into `dev-esm-piControl` which adds the requested commits, and it will leave a comment on the initial PR with the outcome of the command.
 
 
 !!! warning
 
-    The selected commits must exist in the base branch of the PR where the `!cherry-pick` command is run. In the above example, the command will fail if the commits don't exist in `dev-piControl`. For this reason, you must merge the initial PR before using the `!cherry-pick` command.
+    The selected commits must exist in the base branch of the PR where the `!cherry-pick` command is run. In the above example, the command will fail if the commits don't exist in `dev-piControl`. For this reason, you must merge the initial PR before using the `!cherry-pick` command. This is to ensure the commits have been reviewed before the command is run. 
 
 !!! warning
 

--- a/documentation/docs/pages/infrastructure/git-practices.md
+++ b/documentation/docs/pages/infrastructure/git-practices.md
@@ -5,7 +5,7 @@
 There is a workflow which enables semi-automated cherry-picking from one branch into another, using the !cherry-pick keyword in a pull-request. This is useful when changes need to be applied across multiple branches.
 
 For example, if you have made a pull request into `dev-piControl` and want to duplicate the changes in `dev-esm-piControl`:
-1. Finalise and merge the pull request into `dev-piControl`.
+1. First organise your changes into a neat set of commits, and merge the pull request into `dev-piControl`.
 2. Identify the newly created commits in `dev-piControl` which you want to copy over to `dev-esm-piControl`, e.g. `hash1`, `hash2`, ..., `hashn`. This could be all, or just a subset of the commits created by merging the PR, depending on which specific changes you want to copy over. Omit any merge commits from this list, as they are not supported by the automatic cherry pick command.
 3. In a new comment in the just merged PR, use the `!cherry-pick` command as follows:
     `!cherry-pick hash1 hash2 <...> hashn into dev-esm-piControl`
@@ -19,4 +19,4 @@ This will create a new PR into `dev-esm-piControl` which adds the requested comm
 
 !!! warning
 
-    In the case where the initial PR is answer changing, we recommend the following approach. First organise your changes into a neat set of commits, and then run the `!test repro commit` command. Merge the PR using the `Create a merge commit` option rather than the `Squash and merge` option, which will keep the main content of the PR separate from the checksum changes. Finally, identify the newly created non-checksum commits in the the base branch, and use these in the `!cherry-pick` comment command.
+    In the case where the initial PR is answer changing, we recommend the following approach to avoid copying the CI checksum changes. Once the changes in the PR have been neatly organised, run the `!test repro commit` command. Merge the PR using the `Create a merge commit` option rather than the `Squash and merge` option, which will keep the main content of the PR separate from the checksum changes. Finally, identify the newly created non-checksum commits in the the base branch, and use these in the `!cherry-pick` comment command. Remember to run the `!test repro commit` command in the new PRs.

--- a/documentation/docs/pages/infrastructure/git-practices.md
+++ b/documentation/docs/pages/infrastructure/git-practices.md
@@ -2,18 +2,21 @@
 
 ## Automated Cherry Picking
 
-There is a workflow which enables semi-automated cherry-picking from one branch into another, using the !cherry-pick keyword in a pull-request. This is useful when a change needs to be applied across multiple branches.
+There is a workflow which enables semi-automated cherry-picking from one branch into another, using the !cherry-pick keyword in a pull-request. This is useful when changes need to be applied across multiple branches.
 
-For example, if a pull-request changes `dev-piControl`, to apply the change to `dev-esm-piControl`:
-- First finalise and merge the pull-request into `dev-piControl`.
-- Second, as a standalone comment in the pull-request, use the keyword as follows:
-    ` !cherry-pick <commit> into <branch> `
+For example, if you have made a pull request into `dev-piControl` and want to duplicate the changes in `dev-esm-piControl`:
+1. Finalise and merge the pull request into `dev-piControl`.
+2. Identify the newly created commits in `dev-piControl` which you want to copy over to `dev-esm-piControl`, e.g. `hash1`, `hash2`, ..., `hashn`. This could be all, or just a subset of the commits created by merging the PR, depending on which specific changes you want to copy over. Omit any merge commits from this list, as they are not supported by the automatic cherry pick command.
+3. In a new comment in the just merged PR, use the `!cherry-pick` command as follows:
+    `!cherry-pick hash1 hash2 <...> hashn into dev-esm-piControl`
 
-\<commit> must exist in `dev-piControl`. This can be one or multiple commit hashes seperated by spaces.
-\<branch> would be `dev-esm-piControl` in this example
+This will create a new PR into `dev-esm-piControl` which adds the requested commits, and it will leave a comment on the initial PR with the outcome of the command.
 
-This will attempt to make a new pull-request with the request commit(s), and leave a comment on the initial-pull request with the outcome.
 
 !!! warning
 
-    In the case where the PR is answer changing, it's recomended to organise your changes into a neat set of commits prior to using the `!test repro commit` command. When merging, select `Create a merge commit` rather than `Squash and merge`, as this will allow you to select just the non-checksum commits in the `!cherry-pick` comment command.
+    The selected commits must exist in the base branch of the PR where the `!cherry-pick` command is run. In the above example, the command will fail if the commits don't exist in `dev-piControl`. For this reason, you must merge the initial PR before using the `!cherry-pick` command.
+
+!!! warning
+
+    In the case where the initial PR is answer changing, we recommend the following approach. First organise your changes into a neat set of commits, and then run the `!test repro commit` command. Merge the PR using the `Create a merge commit` option rather than the `Squash and merge` option, which will keep the main content of the PR separate from the checksum changes. Finally, identify the newly created non-checksum commits in the the base branch, and use these in the `!cherry-pick` comment command.

--- a/documentation/docs/pages/infrastructure/git-practices.md
+++ b/documentation/docs/pages/infrastructure/git-practices.md
@@ -1,0 +1,19 @@
+# Git practices
+
+## Automated Cherry Picking
+
+There is a workflow which enables semi-automated cherry-picking from one branch into another, using the !cherry-pick keyword in a pull-request. This is useful when a change needs to be applied across multiple branches.
+
+For example, if a pull-request changes `dev-piControl`, to apply the change to `dev-esm-piControl`:
+- First finalise and merge the pull-request into `dev-piControl`.
+- Second, as a standalone comment in the pull-request, use the keyword as follows:
+    ` !cherry-pick <commit> into <branch> `
+
+\<commit> must exist in `dev-piControl`. This can be one or multiple commit hashes seperated by spaces.
+\<branch> would be `dev-esm-piControl` in this example
+
+This will attempt to make a new pull-request with the request commit(s), and leave a comment on the initial-pull request with the outcome.
+
+!!! warning
+
+    In the case where the PR is answer changing, it's recomended to organise your changes into a neat set of commits prior to using the `!test repro commit` command. When merging, select `Create a merge commit` rather than `Squash and merge`, as this will allow you to select just the non-checksum commits in the `!cherry-pick` comment command.


### PR DESCRIPTION
This PR adds a couple of small changes to the cherry picking instructions:
- It moves them to the empty `infrastructure/git-practices` page in the documentation.
- It adds the following note about using the `!cherry-pick` command when a PR is answer changing:
>    In the case where the PR is answer changing, it's recomended to organise your changes into a neat set of commits prior to using the `!test repro commit` command. When merging, select `Create a merge commit` rather than `Squash and merge`, as this will allow you to select just the non-checksum commits in the `!cherry-pick` comment command.

Closes #505 