### PR TITLE
Use the deployed release with runtime params for CICE5 and add params into CICE5 namelist

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -28,9 +28,9 @@ platform:
 # Modules for loading model executables
 modules:
   use:
-      - /g/data/vk83/modules
+      - /g/data/vk83/prerelease/modules
   load:
-      - access-esm1p6/2026.04.001
+      - access-esm1p6/pr221-1
 
 # Model configuration
 model: access-esm1.6
@@ -85,7 +85,7 @@ submodels:
     - name: ice
       model: cice5
       ncpus: 12
-      exe: cice_access_360x300_30x300.exe
+      exe: cice_access.exe
       input:
         # Grids
         - /g/data/vk83/configurations/inputs/access-esm1p6/modern/share/ice/grids/global.1deg/2025.07.29/kmt.nc

--- a/config.yaml
+++ b/config.yaml
@@ -131,7 +131,7 @@ restart_freq: 10YS
 runlog: true
 manifest:
   reproduce:
-    exe: true
+    exe: false
     input: true
 
 stacksize: unlimited

--- a/ice/cice_in.nml
+++ b/ice/cice_in.nml
@@ -25,6 +25,11 @@
 
 &domain_nml
     nprocs = 12
+    nx_global    = 360
+    ny_global    = 300
+    block_size_x = 30
+    block_size_y = 300
+    max_blocks   = 1
     processor_shape   = 'slenderX1'
     distribution_type = 'cartesian'
     distribution_wght = 'latitude'


### PR DESCRIPTION
<!-- This template was created to cover the most complex case of new changes to the configuration. As such, all sections may not be suitable for other types of changes (e.g. documentation changes, cherry-picking changes between configurations). Please fill in all the sections you believe are suitable to your case. The reviewer(s) will ask for any missing information. Please do not delete any empty sections. -->

**1. Summary**:

#### What has changed?
The CICE5 exe can now handle runtime parameters for number of cores, the global grid sizes, the block sizes per MPI rank, and the max. number of blocks. The changes are:
- the exe is now called `cice_<driver>.exe`

Namelist changes:
- `nprocs` (uses the existing required namelist var)
-  `nx_global`, `ny_global`, `block_size_x`, `block_size_y`
-  `max_blocks` can be set to `-1` and the correct value will be derived based on the distribution type. However, `max_blocks` is fixed at 1 for ESM1.6 - otherwise code aborts at runtime

**Note**: Claude backported this feature from CICE6

#### Why was this done?
Makes scaling studies for NCMAS a lot easier, simplifies the CICE5 SPR (not done yet), and just is more aesthetically pleasing


**2. Issues Addressed:**

<!-- Add links to github issue(s) this is related to -->
- https://github.com/ACCESS-NRI/cice5/issues/105
- https://github.com/ACCESS-NRI/ACCESS-ESM1.6/issues/220

**3. Dependencies (e.g. on payu, or model)**

This change requires changes to (note pull request(s) where relevant):
- [ ] workflow manager (payu):
- [x] model deployment (ACCESS-ESM1.6): https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/221
- [x] model component or library dependency:https://github.com/ACCESS-NRI/cice5/pull/113
- [ ] input workflow:

<!-- Describe and link to the related changes to dependencies -->

**4. Ad-hoc Testing**

What ad-hoc testing was done? How are you convinced this change is correct (plots are good)?
Tested with local spack-built exes (with `spack develop`) and outputs are bitwise identical. However, `test repro` here would be the final decider.


**5. CI Testing**
<!-- Has the CI-testing been run? -->
- [ ] `!test repro` has been run

This is a bit of a chicken-or-egg question. I need to create this PR *first*, and then I can run the `test repro` command. Will update once the results are back. I do expect bitwise identical results (or a crash)

**6. Reproducibility**

Is this reproducible with the previous commit? (If not, why not?)
- [ ] Yes
- [ ] No - `!test repro commit` has been run. <!-- add detail below for why it's answer changing -->

**7. Performance**
<!-- check the throughput of the model by running 6 months with and without your changes and recording the walltime-->

Has the model performance (say, throughput of model-years/wall-day) changed? 
- [ ] Yes
- [ ] No
- [x] N/A (if selected, please add a brief explanation why performance testing is not necessary for this PR)

If yes, provide the numbers from your testing. Is the performance better or worse?

**8. Manifests**

Have you changed the executable, the input files and/or the restart files?
- [x] Yes
- [ ] No

If yes, have you updated the manifests?
- [ ] Yes
- [x] No

To update the manifests, run payu setup (in a cloned copy of your feature branch) with reproducibility tests turned off:

```yaml
manifest:
  reproduce:
    exe: false
    input: false
    restart: false
runlog:
  enable: false
```
Then commit the newly created manifest files (under manifests/) only to the branch for this PR.


**9. Documentation**
<!--Does this impact documentation? -->

Is the documentation updated?
- [ ] Yes
- [ ] N/A

**10. Merge Strategy**
<!-- What is the planned merge strategy (Merge commit, Rebase and merge, or squash) ?
If not squash, link to the related issue in the commit descriptions -->

- [ ] Merge commit
- [ ] Rebase and merge
- [x] Squash

